### PR TITLE
feat(registry): 实现基于 Etcd 的服务注册与发现功能

### DIFF
--- a/docs/registry-design.md
+++ b/docs/registry-design.md
@@ -1,0 +1,598 @@
+# Registry 服务注册与发现设计文档
+
+## 1. 目标与原则
+
+`registry` 组件旨在为 Genesis 框架提供标准化的服务注册与发现能力，是微服务架构中的核心基础设施。初期版本基于 Etcd 实现，并深度集成 gRPC Resolver，实现客户端侧负载均衡。
+
+**核心设计原则：**
+
+1. **接口抽象 (Abstraction):** 定义通用的 `Registry` 接口，业务代码不感知底层实现（Etcd/Consul/Nacos）。
+2. **强依赖 Connector (Connector Dependency):** 复用 `pkg/connector` 管理的 Etcd 连接，不自行创建 Client，确保连接池管理和配置的一致性。
+3. **gRPC 原生支持 (Native gRPC Support):** 实现 gRPC `resolver.Builder` 接口，支持标准的 `etcd://<authority>/<service_name>` 解析方式，无缝对接 gRPC 负载均衡。
+4. **本地缓存与高性能 (Local Cache & Performance):** 服务发现层内置本地缓存机制，减少对注册中心的直接请求压力，提升系统吞吐量。
+5. **生命周期管理 (Lifecycle Management):** 实现标准的 `Lifecycle` 接口，自动管理 Lease 续租（KeepAlive）和服务注销，确保服务下线时能够快速从注册中心移除。
+
+## 2. 项目结构
+
+遵循框架整体的分层设计，API 与实现分离：
+
+```text
+genesis/
+├── pkg/
+│   └── registry/               # 公开 API 入口
+│       ├── registry.go         # 工厂函数 (New) + 类型导出
+│       ├── options.go          # Option 定义 (WithLogger, WithMeter, WithTracer)
+│       └── types/              # 类型定义
+│           ├── interface.go    # Registry 接口
+│           ├── service.go      # ServiceInstance 结构定义
+│           ├── config.go       # 配置定义
+│           └── errors.go       # 错误定义
+├── internal/
+│   └── registry/               # 内部实现
+│       └── etcd/               # Etcd 具体实现
+│           ├── registry.go     # 注册逻辑 (Lease, Put)
+│           ├── discovery.go    # 发现逻辑 (Get, Watch, Cache)
+│           ├── resolver.go     # gRPC Resolver Builder 实现
+│           └── watcher.go      # 监听器实现
+└── ...
+```
+
+## 3. 核心 API 设计
+
+核心定义位于 `pkg/registry/types/`。
+
+### 3.1. ServiceInstance 模型
+
+定义服务的元数据模型，兼容 gRPC 属性。
+
+```go
+// pkg/registry/types/service.go
+
+package types
+
+// ServiceInstance 代表一个服务实例
+type ServiceInstance struct {
+    ID        string            `json:"id"`        // 唯一实例 ID (通常是 UUID)
+    Name      string            `json:"name"`      // 服务名称 (如 user-service)
+    Version   string            `json:"version"`   // 版本号
+    Metadata  map[string]string `json:"metadata"`  // 元数据 (Region, Zone, Weight, Group 等)
+    Endpoints []string          `json:"endpoints"` // 服务地址列表 (如 grpc://192.168.1.10:9090)
+}
+```
+
+### 3.2. 核心接口
+
+```go
+// pkg/registry/types/interface.go
+
+package types
+
+import (
+    "context"
+    "time"
+    "google.golang.org/grpc"
+)
+
+// Registry 服务注册与发现接口
+type Registry interface {
+    // --- 服务注册 ---
+    
+    // Register 注册服务实例
+    // ctx: 上下文
+    // service: 服务实例信息
+    // ttl: 租约有效期 (例如 10s)，超时后若无续约服务将自动下线
+    Register(ctx context.Context, service *ServiceInstance, ttl time.Duration) error
+
+    // Deregister 注销服务实例
+    // serviceID: 服务实例 ID
+    Deregister(ctx context.Context, serviceID string) error
+
+    // --- 服务发现 ---
+    
+    // GetService 获取服务实例列表
+    // 优先读取本地缓存，缓存未命中或过期时查询注册中心
+    GetService(ctx context.Context, serviceName string) ([]*ServiceInstance, error)
+
+    // Watch 监听服务实例变化
+    // 返回一个事件通道，接收服务变化事件 (PUT/DELETE)
+    Watch(ctx context.Context, serviceName string) (<-chan ServiceEvent, error)
+
+    // --- gRPC 集成 ---
+    
+    // GetConnection 获取到指定服务的 gRPC 连接
+    // 内部封装了 Resolver 和 Balancer 的配置，提供开箱即用的连接对象
+    // 支持自动服务发现和客户端负载均衡
+    GetConnection(ctx context.Context, serviceName string, opts ...grpc.DialOption) (*grpc.ClientConn, error)
+
+    // --- 生命周期管理 ---
+    
+    // Start 启动后台任务 (Lease KeepAlive、Watch 监听等)
+    Start(ctx context.Context) error
+    
+    // Stop 停止后台任务并清理资源
+    Stop(ctx context.Context) error
+    
+    // Phase 返回启动阶段 (建议 20，与其他业务组件一致)
+    Phase() int
+}
+
+// ServiceEvent 服务变化事件
+type ServiceEvent struct {
+    Type    EventType        // 事件类型 (PUT/DELETE)
+    Service *ServiceInstance // 服务实例信息
+}
+
+// EventType 事件类型
+type EventType string
+
+const (
+    EventTypePut    EventType = "PUT"    // 服务注册或更新
+    EventTypeDelete EventType = "DELETE" // 服务注销
+)
+```
+
+### 3.3. 配置 (Config)
+
+```go
+// pkg/registry/types/config.go
+
+package types
+
+import "time"
+
+type Config struct {
+    // Namespace Etcd Key 前缀，默认 "/genesis/services"
+    Namespace string `yaml:"namespace" json:"namespace"`
+
+    // Schema 注册到 gRPC resolver 的 schema，默认 "etcd"
+    Schema string `yaml:"schema" json:"schema"`
+
+    // DefaultTTL 默认服务注册租约时长，默认 30s
+    DefaultTTL time.Duration `yaml:"default_ttl" json:"default_ttl"`
+
+    // RetryInterval 重连/重试间隔，默认 1s
+    RetryInterval time.Duration `yaml:"retry_interval" json:"retry_interval"`
+
+    // EnableCache 是否启用本地服务发现缓存，默认 true
+    EnableCache bool `yaml:"enable_cache" json:"enable_cache"`
+
+    // CacheExpiration 本地缓存过期时间，默认 10s
+    CacheExpiration time.Duration `yaml:"cache_expiration" json:"cache_expiration"`
+}
+```
+
+### 3.4. 组件初始化选项 (Option)
+
+遵循组件规范，使用 Option 模式注入可观测性依赖。
+
+```go
+// pkg/registry/options.go
+
+package registry
+
+import (
+    "github.com/ceyewan/genesis/pkg/clog"
+    "github.com/ceyewan/genesis/pkg/telemetry/types"
+)
+
+// Option 组件初始化选项函数
+type Option func(*options)
+
+// options 选项结构
+type options struct {
+    logger clog.Logger
+    meter  types.Meter
+    tracer types.Tracer
+}
+
+// WithLogger 注入日志记录器
+// 组件内部会自动追加 "registry" namespace
+func WithLogger(l clog.Logger) Option {
+    return func(o *options) {
+        if l != nil {
+            o.logger = l.WithNamespace("registry")
+        }
+    }
+}
+
+// WithMeter 注入指标 Meter
+func WithMeter(m types.Meter) Option {
+    return func(o *options) {
+        o.meter = m
+    }
+}
+
+// WithTracer 注入 Tracer
+func WithTracer(t types.Tracer) Option {
+    return func(o *options) {
+        o.tracer = t
+    }
+}
+```
+
+## 4. Etcd 实现设计
+
+### 4.1. 存储 Schema
+
+Etcd Key 采用层级结构设计，便于 Watch 前缀：
+
+```text
+<namespace>/<service_name>/<instance_id> -> JSON(ServiceInstance)
+```
+
+例如：`/genesis/services/user-service/uuid-1234-5678`
+
+### 4.2. 注册流程 (Register)
+
+1. **Grant Lease:** 使用传入的 `ttl` 创建 Lease。
+2. **KeepAlive:** 启动后台 Goroutine 对该 Lease ID 进行自动续约。
+3. **Put:** 将 `ServiceInstance` 序列化为 JSON，调用 Etcd Put 操作，并绑定该 Lease。
+4. **Deregister:** 调用 Delete 删除 Key，并 Revoke Lease。
+5. **异常处理:** 如果 KeepAlive 通道关闭，尝试重连并重新注册。
+
+### 4.3. 发现流程与本地缓存 (Discovery & Local Cache)
+
+1. **Watch:** 启动 `clientv3.Watch` 监听 `<namespace>/<service_name>/` 前缀。
+2. **Local Cache:**
+    * Discovery 内部维护 `map[string][]*ServiceInstance` 缓存。
+    * Watch 事件（PUT/DELETE）实时更新本地缓存。
+    * `GetService` 直接返回缓存数据，实现高性能读取。
+    * 支持通过配置启用/禁用缓存。
+3. **GetConnection:**
+    * 内部构建 gRPC Target: `etcd:///<service_name>` (假设 scheme 配置为 etcd)。
+    * 调用 `grpc.Dial`，并注入默认的 Load Balancing Config (如 round_robin)。
+
+### 4.4. 生命周期管理
+
+```go
+// internal/registry/etcd/registry.go
+
+type EtcdRegistry struct {
+    client    *clientv3.Client
+    cfg       types.Config
+    logger    clog.Logger
+    meter     telemetrytypes.Meter
+    tracer    telemetrytypes.Tracer
+    
+    // 后台任务管理
+    leases    map[string]clientv3.LeaseID  // serviceID -> leaseID
+    watchers  map[string]context.CancelFunc // serviceName -> cancel
+    cache     map[string][]*types.ServiceInstance // 本地缓存
+    stopChan  chan struct{}
+    wg        sync.WaitGroup
+    mu        sync.RWMutex
+}
+
+func (r *EtcdRegistry) Start(ctx context.Context) error {
+    r.logger.Info("starting registry service")
+    // 启动已注册服务的 lease keepalive
+    // 初始化本地缓存
+    return nil
+}
+
+func (r *EtcdRegistry) Stop(ctx context.Context) error {
+    r.logger.Info("stopping registry service")
+    close(r.stopChan)
+    
+    // 停止所有 watchers
+    r.mu.Lock()
+    for _, cancel := range r.watchers {
+        cancel()
+    }
+    r.watchers = nil
+    
+    // 撤销所有 leases
+    for _, leaseID := range r.leases {
+        r.client.Revoke(ctx, leaseID)
+    }
+    r.leases = nil
+    r.mu.Unlock()
+    
+    r.wg.Wait()
+    return nil
+}
+
+func (r *EtcdRegistry) Phase() int {
+    return 20 // 与其他业务组件一致
+}
+```
+
+## 5. gRPC Resolver 集成
+
+为了让 gRPC 客户端能自动发现服务，组件将实现 `google.golang.org/grpc/resolver`。
+
+### 5.1. 原理
+
+gRPC Resolver 机制允许自定义 naming system。我们将实现一个 Builder，注册 scheme 为 `etcd`。
+
+当用户调用 `grpc.Dial("etcd:///user-service", ...)` 时：
+
+1. gRPC 解析出 Scheme 为 `etcd`，Endpoint 为 `user-service`。
+2. 调用我们注册的 Builder 的 `Build` 方法。
+3. Builder 内部调用 `Watch("user-service")` 获取事件通道。
+4. 启动 Goroutine 循环监听事件通道。
+5. 当收到事件时，将服务列表转换为 `[]resolver.Address` 并调用 `ClientConn.UpdateState` 更新 gRPC 内部的连接列表。
+
+### 5.2. 负载均衡
+
+Resolver 只负责更新地址列表。负载均衡由 gRPC 客户端的 Balancer 实现（默认配置为 `round_robin`）。
+
+## 6. 工厂函数设计
+
+### 6.1. 独立模式工厂函数
+
+```go
+// pkg/registry/registry.go
+
+package registry
+
+import (
+    "github.com/ceyewan/genesis/pkg/connector"
+    "github.com/ceyewan/genesis/pkg/registry/types"
+    internalregistry "github.com/ceyewan/genesis/internal/registry/etcd"
+)
+
+// New 创建 Registry 实例（基于 Etcd）
+// conn: Etcd 连接器
+// cfg: 组件配置
+// opts: 可选参数 (Logger, Meter, Tracer)
+func New(conn connector.EtcdConnector, cfg types.Config, opts ...Option) (types.Registry, error) {
+    // 应用选项
+    opt := defaultOptions()
+    for _, o := range opts {
+        o(&opt)
+    }
+    
+    // 调用内部实现
+    return internalregistry.New(conn, cfg, opt.logger, opt.meter, opt.tracer)
+}
+
+func defaultOptions() *options {
+    return &options{
+        logger: clog.Default(), // 默认 Logger
+    }
+}
+```
+
+### 6.2. 容器模式集成
+
+在 Container 中自动初始化 Registry 组件。
+
+```go
+// pkg/container/container.go
+
+func (c *Container) initRegistry(cfg *types.Config) error {
+    // 获取 Etcd 连接器
+    etcdConn, err := c.GetEtcdConnector(cfg.Etcd)
+    if err != nil {
+        return err
+    }
+
+    // 创建 Registry 实例
+    reg, err := registry.New(etcdConn, cfg.Registry,
+        registry.WithLogger(c.Logger),
+        registry.WithMeter(c.Meter),
+        registry.WithTracer(c.Tracer),
+    )
+    if err != nil {
+        return err
+    }
+
+    c.Registry = reg
+    
+    // 注册为 Lifecycle 对象
+    c.registerLifecycle(reg)
+    
+    return nil
+}
+```
+
+## 7. 使用示例
+
+### 7.1. 独立模式
+
+```go
+package main
+
+import (
+    "context"
+    "time"
+
+    "github.com/ceyewan/genesis/pkg/clog"
+    "github.com/ceyewan/genesis/pkg/connector"
+    "github.com/ceyewan/genesis/pkg/registry"
+    "github.com/ceyewan/genesis/pkg/registry/types"
+)
+
+func main() {
+    // 创建 Logger
+    logger := clog.New(&clog.Config{
+        Level:  "info",
+        Format: "json",
+    })
+
+    // 创建 Etcd 连接器
+    etcdConn, _ := connector.NewEtcd(&connector.EtcdConfig{
+        Endpoints: []string{"localhost:2379"},
+    })
+
+    // 创建 Registry 实例
+    reg, _ := registry.New(etcdConn, types.Config{
+        Namespace:       "/genesis/services",
+        Schema:          "etcd",
+        DefaultTTL:      30 * time.Second,
+        RetryInterval:   1 * time.Second,
+        EnableCache:     true,
+        CacheExpiration: 10 * time.Second,
+    }, registry.WithLogger(logger))
+
+    // 启动 Registry
+    ctx := context.Background()
+    reg.Start(ctx)
+    defer reg.Stop(ctx)
+
+    // 定义服务实例
+    svc := &types.ServiceInstance{
+        ID:        "user-service-1",
+        Name:      "user-service",
+        Endpoints: []string{"grpc://192.168.1.100:8080"},
+        Version:   "1.0.0",
+        Metadata: map[string]string{
+            "region": "us-west-1",
+        },
+    }
+
+    // 注册服务，指定 30s TTL
+    if err := reg.Register(ctx, svc, 30*time.Second); err != nil {
+        logger.Error("failed to register", clog.Error(err))
+        return
+    }
+    defer reg.Deregister(ctx, svc.ID)
+
+    // 服务保持运行...
+}
+```
+
+### 7.2. 容器模式
+
+```go
+package main
+
+import (
+    "context"
+    "time"
+
+    "github.com/ceyewan/genesis/pkg/config"
+    "github.com/ceyewan/genesis/pkg/container"
+)
+
+func main() {
+    // 加载配置
+    cfgMgr := config.NewManager(config.WithPaths("./config"))
+    _ = cfgMgr.Load(context.Background())
+    
+    var appCfg AppConfig
+    _ = cfgMgr.Unmarshal(&appCfg)
+
+    // 创建 Container
+    app, _ := container.New(&appCfg, container.WithConfigManager(cfgMgr))
+    defer app.Close()
+
+    ctx := context.Background()
+
+    // 定义服务实例
+    svc := &types.ServiceInstance{
+        ID:        "user-service-1",
+        Name:      "user-service",
+        Endpoints: []string{"grpc://192.168.1.100:8080"},
+    }
+
+    // 注册服务
+    if err := app.Registry.Register(ctx, svc, 30*time.Second); err != nil {
+        app.Logger.Error("failed to register", clog.Error(err))
+        return
+    }
+    defer app.Registry.Deregister(ctx, svc.ID)
+
+    // 服务保持运行...
+}
+```
+
+### 7.3. 客户端发现 (方式一: GetConnection)
+
+```go
+// 直接获取连接，开箱即用
+conn, err := reg.GetConnection(ctx, "user-service")
+if err != nil {
+    panic(err)
+}
+defer conn.Close()
+
+// 使用 conn 调用 gRPC 服务
+client := pb.NewUserServiceClient(conn)
+resp, err := client.GetUser(ctx, &pb.GetUserRequest{ID: "123"})
+```
+
+### 7.4. 客户端发现 (方式二: 原生 gRPC Dial)
+
+```go
+import (
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
+)
+
+// Registry 初始化时已自动注册 gRPC Resolver Builder
+
+// 使用标准 gRPC Dial
+conn, err := grpc.Dial(
+    "etcd:///user-service",
+    grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
+    grpc.WithTransportCredentials(insecure.NewCredentials()),
+)
+if err != nil {
+    panic(err)
+}
+defer conn.Close()
+
+// 使用连接
+client := pb.NewUserServiceClient(conn)
+```
+
+### 7.5. 监听服务变化
+
+```go
+// 监听服务变化
+eventCh, err := reg.Watch(ctx, "user-service")
+if err != nil {
+    logger.Error("failed to watch", clog.Error(err))
+    return
+}
+
+// 处理事件
+go func() {
+    for event := range eventCh {
+        switch event.Type {
+        case types.EventTypePut:
+            logger.Info("service registered/updated",
+                clog.String("service_id", event.Service.ID),
+                clog.String("endpoints", strings.Join(event.Service.Endpoints, ",")))
+        case types.EventTypeDelete:
+            logger.Info("service deregistered",
+                clog.String("service_id", event.Service.ID))
+        }
+    }
+}()
+```
+
+## 8. 与现有组件的一致性对比
+
+| 维度 | cache | dlock | registry |
+|------|-------|-------|----------|
+| **接口数量** | 1 个 | 1 个 | 1 个 ✅ |
+| **工厂函数** | `New(conn, cfg, opts)` | `NewRedis(conn, cfg, opts)` | `New(conn, cfg, opts)` ✅ |
+| **Lifecycle** | `Close()` | 无 | 完整 `Start/Stop/Phase` ✅ |
+| **配置完整性** | ✅ | ✅ | ✅ 包含 TTL/Retry/Cache |
+| **Option 模式** | ✅ | ✅ | ✅ |
+| **Logger Namespace** | ✅ 自动派生 | ✅ 自动派生 | ✅ 自动派生 |
+| **依赖注入** | Connector | Connector | Connector ✅ |
+
+## 9. 总结
+
+本设计文档完整定义了 Genesis Registry 组件的架构、接口和实现方案：
+
+**核心特性：**
+
+1. ✅ **统一接口** - 单一 `Registry` 接口，职责清晰
+2. ✅ **gRPC 原生支持** - `GetConnection` 方法提供开箱即用的服务发现
+3. ✅ **完整生命周期** - 实现 `Lifecycle` 接口，支持优雅启停
+4. ✅ **本地缓存** - 可配置的服务发现缓存，提升性能
+5. ✅ **自动续约** - Lease KeepAlive 机制确保服务可用性
+6. ✅ **实时监听** - Watch 机制实时感知服务变化
+7. ✅ **标准化** - 遵循 Genesis 组件开发规范
+
+**与框架集成：**
+
+* 依赖注入：通过 `connector.EtcdConnector` 获取连接
+* 可观测性：通过 Option 注入 Logger/Meter/Tracer
+* 生命周期：由 Container 统一管理启停顺序
+* 配置管理：使用结构化配置，支持热更新

--- a/examples/grpc-registry/main.go
+++ b/examples/grpc-registry/main.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"github.com/ceyewan/genesis/pkg/clog"
+	"github.com/ceyewan/genesis/pkg/connector"
+	"github.com/ceyewan/genesis/pkg/container"
+	"github.com/ceyewan/genesis/pkg/registry"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// 演示 gRPC Resolver 动态服务发现功能
+func main() {
+	fmt.Println("=== gRPC Resolver 动态服务发现演示 ===")
+	fmt.Println("注意：此演示需要运行 etcd 服务")
+	fmt.Println("启动命令：etcd --listen-client-urls=http://localhost:2379 --advertise-client-urls=http://localhost:2379")
+	fmt.Println()
+
+	// 1. 创建容器和 Registry
+	app, err := container.New(&container.Config{
+		Etcd: &connector.EtcdConfig{
+			Endpoints: []string{"localhost:2379"},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create container: %v", err)
+	}
+	defer app.Close()
+
+	logger := clog.Default()
+
+	etcdConn, err := app.GetEtcdConnector(connector.EtcdConfig{
+		Endpoints: []string{"localhost:2379"},
+	})
+	if err != nil {
+		log.Fatalf("Failed to get etcd connector: %v", err)
+	}
+
+	reg, err := registry.New(etcdConn, registry.Config{
+		Namespace:       "/genesis/services",
+		Schema:          "etcd",
+		DefaultTTL:      30 * time.Second,
+		RetryInterval:   1 * time.Second,
+		EnableCache:     true,
+		CacheExpiration: 10 * time.Second,
+	}, registry.WithLogger(logger))
+	if err != nil {
+		log.Fatalf("Failed to create registry: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if err := reg.Start(ctx); err != nil {
+		log.Fatalf("Failed to start registry: %v", err)
+	}
+	defer reg.Stop(ctx)
+
+	serviceName := "demo-service"
+
+	// 2. 启动第一个服务实例
+	fmt.Println("1. 启动第一个服务实例...")
+	server1, addr1 := startTestServer("server-1")
+	defer server1.Stop()
+
+	service1 := &registry.ServiceInstance{
+		ID:        "demo-service-1",
+		Name:      serviceName,
+		Version:   "1.0.0",
+		Endpoints: []string{fmt.Sprintf("grpc://%s:%d", addr1.IP.String(), addr1.Port)},
+		Metadata: map[string]string{
+			"version": "1.0.0",
+			"server":  "server-1",
+		},
+	}
+
+	err = reg.Register(ctx, service1, 30*time.Second)
+	if err != nil {
+		log.Fatalf("Failed to register service 1: %v", err)
+	}
+	defer reg.Deregister(ctx, service1.ID)
+
+	fmt.Printf("✓ 服务实例 1 已注册: %s\n", service1.Endpoints[0])
+
+	// 等待服务注册生效
+	time.Sleep(500 * time.Millisecond)
+
+	// 3. 使用 gRPC resolver 创建连接
+	fmt.Println("\n2. 使用 gRPC resolver 创建连接...")
+	conn, err := reg.GetConnection(ctx, serviceName)
+	if err != nil {
+		log.Fatalf("Failed to create gRPC connection: %v", err)
+	}
+	defer conn.Close()
+
+	client := grpc_health_v1.NewHealthClient(conn)
+	fmt.Println("✓ gRPC 连接已建立，使用动态服务发现")
+
+	// 4. 测试连接
+	fmt.Println("\n3. 测试连接...")
+	for i := 0; i < 3; i++ {
+		resp, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		if err != nil {
+			log.Printf("Health check failed: %v", err)
+		} else {
+			fmt.Printf("✓ 健康检查 %d: %v\n", i+1, resp.Status)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// 5. 动态添加第二个服务实例
+	fmt.Println("\n4. 动态添加第二个服务实例...")
+	server2, addr2 := startTestServer("server-2")
+	defer server2.Stop()
+
+	service2 := &registry.ServiceInstance{
+		ID:        "demo-service-2",
+		Name:      serviceName,
+		Version:   "1.0.1",
+		Endpoints: []string{fmt.Sprintf("grpc://%s:%d", addr2.IP.String(), addr2.Port)},
+		Metadata: map[string]string{
+			"version": "1.0.1",
+			"server":  "server-2",
+		},
+	}
+
+	err = reg.Register(ctx, service2, 30*time.Second)
+	if err != nil {
+		log.Fatalf("Failed to register service 2: %v", err)
+	}
+	defer reg.Deregister(ctx, service2.ID)
+
+	fmt.Printf("✓ 服务实例 2 已注册: %s\n", service2.Endpoints[0])
+
+	// 等待 resolver 检测到新服务
+	fmt.Println("⏳ 等待 resolver 检测到新服务...")
+	time.Sleep(1 * time.Second)
+
+	// 6. 验证负载均衡
+	fmt.Println("\n5. 验证负载均衡（现在有两个服务实例）...")
+	for i := 0; i < 6; i++ {
+		resp, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		if err != nil {
+			log.Printf("Health check failed: %v", err)
+		} else {
+			fmt.Printf("✓ 负载均衡测试 %d: %v\n", i+1, resp.Status)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// 7. 移除第一个服务实例
+	fmt.Println("\n6. 移除第一个服务实例...")
+	err = reg.Deregister(ctx, service1.ID)
+	if err != nil {
+		log.Printf("Failed to unregister service 1: %v", err)
+	} else {
+		fmt.Println("✓ 服务实例 1 已移除")
+	}
+
+	// 等待 resolver 检测到服务移除
+	fmt.Println("⏳ 等待 resolver 检测到服务移除...")
+	time.Sleep(1 * time.Second)
+
+	// 8. 验证连接仍然可用
+	fmt.Println("\n7. 验证连接仍然可用（只剩一个服务实例）...")
+	for i := 0; i < 3; i++ {
+		resp, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		if err != nil {
+			log.Printf("Health check failed: %v", err)
+		} else {
+			fmt.Printf("✓ 故障转移测试 %d: %v\n", i+1, resp.Status)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// 9. 验证服务发现
+	fmt.Println("\n8. 验证服务发现...")
+	services, err := reg.GetService(ctx, serviceName)
+	if err != nil {
+		log.Printf("Failed to discover services: %v", err)
+	} else {
+		fmt.Printf("✓ 发现 %d 个服务实例:\n", len(services))
+		for _, svc := range services {
+			fmt.Printf("  - ID: %s, Endpoints: %v, Version: %s\n",
+				svc.ID, svc.Endpoints, svc.Metadata["version"])
+		}
+	}
+
+	fmt.Println("\n=== 演示完成 ===")
+	fmt.Println("✅ gRPC resolver 成功实现了动态服务发现和负载均衡！")
+	fmt.Println("\n主要特性:")
+	fmt.Println("  • 动态服务发现：自动检测新增的服务实例")
+	fmt.Println("  • 负载均衡：使用 round_robin 策略分发请求")
+	fmt.Println("  • 故障转移：服务实例下线时自动切换到可用实例")
+	fmt.Println("  • 实时更新：通过 etcd watch 机制实时感知服务变化")
+}
+
+// startTestServer 启动一个测试用的 gRPC 服务器
+func startTestServer(serverID string) (*grpc.Server, *net.TCPAddr) {
+	// 监听随机端口
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatalf("Failed to listen: %v", err)
+	}
+
+	server := grpc.NewServer()
+
+	// 注册健康检查服务
+	healthServer := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, healthServer)
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// 启动服务器
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			log.Printf("Server %s exited with error: %v", serverID, err)
+		}
+	}()
+
+	// 等待服务器启动
+	time.Sleep(100 * time.Millisecond)
+
+	addr := lis.Addr().(*net.TCPAddr)
+	log.Printf("Test server %s started on %s", serverID, addr)
+
+	return server, addr
+}

--- a/examples/registry/main.go
+++ b/examples/registry/main.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/ceyewan/genesis/pkg/clog"
+	"github.com/ceyewan/genesis/pkg/connector"
+	"github.com/ceyewan/genesis/pkg/container"
+	"github.com/ceyewan/genesis/pkg/registry"
+)
+
+func main() {
+	fmt.Println("=== Registry Service Registration & Discovery Example ===\n")
+
+	// 1. 创建容器以管理连接器
+	app, err := container.New(&container.Config{
+		Etcd: &connector.EtcdConfig{
+			Endpoints: []string{"localhost:2379"},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to create container: %v", err)
+	}
+	defer app.Close()
+
+	// 2. 创建 Logger
+	logger := clog.Default()
+
+	// 3. 获取 Etcd 连接器
+	etcdConn, err := app.GetEtcdConnector(connector.EtcdConfig{
+		Endpoints: []string{"localhost:2379"},
+	})
+	if err != nil {
+		log.Fatalf("Failed to get etcd connector: %v", err)
+	}
+
+	// 4. 创建 Registry 实例
+	reg, err := registry.New(etcdConn, registry.Config{
+		Namespace:       "/genesis/services",
+		Schema:          "etcd",
+		DefaultTTL:      30 * time.Second,
+		RetryInterval:   1 * time.Second,
+		EnableCache:     true,
+		CacheExpiration: 10 * time.Second,
+	}, registry.WithLogger(logger))
+	if err != nil {
+		log.Fatalf("Failed to create registry: %v", err)
+	}
+
+	// 5. 启动 Registry
+	ctx := context.Background()
+	if err := reg.Start(ctx); err != nil {
+		log.Fatalf("Failed to start registry: %v", err)
+	}
+	defer reg.Stop(ctx)
+
+	// 6. 注册服务实例
+	service := &registry.ServiceInstance{
+		ID:        "user-service-001",
+		Name:      "user-service",
+		Version:   "1.0.0",
+		Endpoints: []string{"grpc://127.0.0.1:9001"},
+		Metadata: map[string]string{
+			"region": "us-west-1",
+			"zone":   "zone-a",
+		},
+	}
+
+	fmt.Println("1. Registering service instance...")
+	if err := reg.Register(ctx, service, 30*time.Second); err != nil {
+		log.Fatalf("Failed to register service: %v", err)
+	}
+	fmt.Printf("✓ Service registered: %s (ID: %s)\n\n", service.Name, service.ID)
+
+	// 确保在退出时注销服务
+	defer func() {
+		fmt.Println("\n6. Deregistering service...")
+		if err := reg.Deregister(ctx, service.ID); err != nil {
+			log.Printf("Failed to deregister service: %v", err)
+		} else {
+			fmt.Println("✓ Service deregistered")
+		}
+	}()
+
+	// 7. 服务发现
+	fmt.Println("2. Discovering services...")
+	time.Sleep(500 * time.Millisecond) // 等待注册生效
+	instances, err := reg.GetService(ctx, "user-service")
+	if err != nil {
+		log.Fatalf("Failed to get service: %v", err)
+	}
+	fmt.Printf("✓ Found %d instance(s):\n", len(instances))
+	for _, inst := range instances {
+		fmt.Printf("  - ID: %s, Endpoints: %v, Version: %s\n",
+			inst.ID, inst.Endpoints, inst.Version)
+	}
+	fmt.Println()
+
+	// 8. 监听服务变化
+	fmt.Println("3. Watching service changes...")
+	watchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	eventCh, err := reg.Watch(watchCtx, "user-service")
+	if err != nil {
+		log.Fatalf("Failed to watch service: %v", err)
+	}
+
+	// 启动事件监听
+	go func() {
+		for event := range eventCh {
+			switch event.Type {
+			case registry.EventTypePut:
+				fmt.Printf("✓ Event: Service %s registered/updated (ID: %s)\n",
+					event.Service.Name, event.Service.ID)
+			case registry.EventTypeDelete:
+				fmt.Printf("✓ Event: Service %s deleted (ID: %s)\n",
+					event.Service.Name, event.Service.ID)
+			}
+		}
+	}()
+
+	// 9. 注册第二个实例
+	time.Sleep(1 * time.Second)
+	fmt.Println("\n4. Registering second service instance...")
+	service2 := &registry.ServiceInstance{
+		ID:        "user-service-002",
+		Name:      "user-service",
+		Version:   "1.0.0",
+		Endpoints: []string{"grpc://127.0.0.1:9002"},
+		Metadata: map[string]string{
+			"region": "us-west-1",
+			"zone":   "zone-b",
+		},
+	}
+
+	if err := reg.Register(ctx, service2, 30*time.Second); err != nil {
+		log.Fatalf("Failed to register service 2: %v", err)
+	}
+	fmt.Printf("✓ Service registered: %s (ID: %s)\n", service2.Name, service2.ID)
+
+	defer func() {
+		if err := reg.Deregister(ctx, service2.ID); err != nil {
+			log.Printf("Failed to deregister service 2: %v", err)
+		}
+	}()
+
+	// 10. 再次查询服务列表
+	time.Sleep(1 * time.Second)
+	fmt.Println("\n5. Discovering services again...")
+	instances, err = reg.GetService(ctx, "user-service")
+	if err != nil {
+		log.Fatalf("Failed to get service: %v", err)
+	}
+	fmt.Printf("✓ Found %d instance(s):\n", len(instances))
+	for _, inst := range instances {
+		fmt.Printf("  - ID: %s, Endpoints: %v\n", inst.ID, inst.Endpoints)
+	}
+
+	// 等待一段时间以观察事件
+	fmt.Println("\nWaiting for events...")
+	time.Sleep(3 * time.Second)
+
+	fmt.Println("\n=== Example Completed ===")
+	fmt.Println("\nKey Features Demonstrated:")
+	fmt.Println("  ✓ Service Registration with TTL and KeepAlive")
+	fmt.Println("  ✓ Service Discovery with Local Cache")
+	fmt.Println("  ✓ Service Watch with Real-time Events")
+	fmt.Println("  ✓ Multiple Service Instances")
+	fmt.Println("  ✓ Graceful Deregistration")
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/sdk/metric v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
+	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.75.0
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/gorm v1.31.1
@@ -102,7 +103,6 @@ require (
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect

--- a/internal/registry/etcd/registry.go
+++ b/internal/registry/etcd/registry.go
@@ -1,0 +1,479 @@
+package etcd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ceyewan/genesis/pkg/clog"
+	"github.com/ceyewan/genesis/pkg/connector"
+	"github.com/ceyewan/genesis/pkg/registry/types"
+	telemetrytypes "github.com/ceyewan/genesis/pkg/telemetry/types"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/resolver"
+)
+
+// EtcdRegistry 基于 Etcd 的服务注册发现实现
+type EtcdRegistry struct {
+	client *clientv3.Client
+	cfg    types.Config
+	logger clog.Logger
+	meter  telemetrytypes.Meter
+	tracer telemetrytypes.Tracer
+
+	// 后台任务管理
+	leases   map[string]clientv3.LeaseID         // serviceID -> leaseID
+	watchers map[string]context.CancelFunc       // serviceName -> cancel
+	cache    map[string][]*types.ServiceInstance // serviceName -> instances
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+	mu       sync.RWMutex
+
+	// resolver builder
+	resolverBuilder *etcdResolverBuilder
+}
+
+// New 创建 EtcdRegistry 实例
+func New(
+	conn connector.EtcdConnector,
+	cfg types.Config,
+	logger clog.Logger,
+	meter telemetrytypes.Meter,
+	tracer telemetrytypes.Tracer,
+) (*EtcdRegistry, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("etcd connector cannot be nil")
+	}
+
+	client := conn.GetClient()
+	if client == nil {
+		return nil, fmt.Errorf("etcd client cannot be nil")
+	}
+
+	// 设置默认值
+	if cfg.Namespace == "" {
+		cfg.Namespace = "/genesis/services"
+	}
+	if cfg.Schema == "" {
+		cfg.Schema = "etcd"
+	}
+	if cfg.DefaultTTL == 0 {
+		cfg.DefaultTTL = 30 * time.Second
+	}
+	if cfg.RetryInterval == 0 {
+		cfg.RetryInterval = 1 * time.Second
+	}
+	if cfg.CacheExpiration == 0 {
+		cfg.CacheExpiration = 10 * time.Second
+	}
+
+	if logger == nil {
+		logger = clog.Default()
+	}
+
+	r := &EtcdRegistry{
+		client:   client,
+		cfg:      cfg,
+		logger:   logger,
+		meter:    meter,
+		tracer:   tracer,
+		leases:   make(map[string]clientv3.LeaseID),
+		watchers: make(map[string]context.CancelFunc),
+		cache:    make(map[string][]*types.ServiceInstance),
+		stopChan: make(chan struct{}),
+	}
+
+	// 创建 resolver builder
+	r.resolverBuilder = newEtcdResolverBuilder(r, cfg.Schema)
+
+	// 注册 gRPC resolver
+	resolver.Register(r.resolverBuilder)
+
+	return r, nil
+}
+
+// Register 注册服务实例
+func (r *EtcdRegistry) Register(ctx context.Context, service *types.ServiceInstance, ttl time.Duration) error {
+	if service == nil || service.ID == "" || service.Name == "" {
+		return types.ErrInvalidServiceInstance
+	}
+
+	if ttl == 0 {
+		ttl = r.cfg.DefaultTTL
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// 检查是否已注册
+	if _, exists := r.leases[service.ID]; exists {
+		return types.ErrServiceAlreadyRegistered
+	}
+
+	// 创建租约
+	lease, err := r.client.Grant(ctx, int64(ttl.Seconds()))
+	if err != nil {
+		r.logger.Error("failed to grant lease",
+			clog.String("service_id", service.ID),
+			clog.Error(err))
+		return fmt.Errorf("grant lease failed: %w", err)
+	}
+
+	// 序列化服务实例
+	value, err := json.Marshal(service)
+	if err != nil {
+		r.client.Revoke(ctx, lease.ID)
+		return fmt.Errorf("marshal service failed: %w", err)
+	}
+
+	// 生成 key
+	key := r.buildKey(service.Name, service.ID)
+
+	// 写入 Etcd
+	_, err = r.client.Put(ctx, key, string(value), clientv3.WithLease(lease.ID))
+	if err != nil {
+		r.client.Revoke(ctx, lease.ID)
+		r.logger.Error("failed to put service",
+			clog.String("key", key),
+			clog.Error(err))
+		return fmt.Errorf("put service failed: %w", err)
+	}
+
+	// 保存 lease ID
+	r.leases[service.ID] = lease.ID
+
+	// 启动 KeepAlive
+	r.wg.Add(1)
+	go r.keepAlive(service.ID, lease.ID)
+
+	r.logger.Info("service registered",
+		clog.String("service_id", service.ID),
+		clog.String("service_name", service.Name),
+		clog.Duration("ttl", ttl))
+
+	return nil
+}
+
+// Deregister 注销服务实例
+func (r *EtcdRegistry) Deregister(ctx context.Context, serviceID string) error {
+	if serviceID == "" {
+		return types.ErrInvalidServiceInstance
+	}
+
+	r.mu.Lock()
+	leaseID, exists := r.leases[serviceID]
+	if !exists {
+		r.mu.Unlock()
+		return types.ErrServiceNotFound
+	}
+	delete(r.leases, serviceID)
+	r.mu.Unlock()
+
+	// 撤销租约（会自动删除关联的 key）
+	if _, err := r.client.Revoke(ctx, leaseID); err != nil {
+		r.logger.Error("failed to revoke lease",
+			clog.String("service_id", serviceID),
+			clog.Error(err))
+		return fmt.Errorf("revoke lease failed: %w", err)
+	}
+
+	r.logger.Info("service deregistered",
+		clog.String("service_id", serviceID))
+
+	return nil
+}
+
+// GetService 获取服务实例列表
+func (r *EtcdRegistry) GetService(ctx context.Context, serviceName string) ([]*types.ServiceInstance, error) {
+	if serviceName == "" {
+		return nil, types.ErrInvalidServiceInstance
+	}
+
+	// 如果启用缓存，先尝试从缓存获取
+	if r.cfg.EnableCache {
+		r.mu.RLock()
+		instances, exists := r.cache[serviceName]
+		r.mu.RUnlock()
+		if exists && len(instances) > 0 {
+			return instances, nil
+		}
+	}
+
+	// 从 Etcd 获取
+	prefix := r.buildPrefix(serviceName)
+	resp, err := r.client.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		r.logger.Error("failed to get service",
+			clog.String("service_name", serviceName),
+			clog.Error(err))
+		return nil, fmt.Errorf("get service failed: %w", err)
+	}
+
+	var instances []*types.ServiceInstance
+	for _, kv := range resp.Kvs {
+		var instance types.ServiceInstance
+		if err := json.Unmarshal(kv.Value, &instance); err != nil {
+			r.logger.Warn("failed to unmarshal service instance",
+				clog.String("key", string(kv.Key)),
+				clog.Error(err))
+			continue
+		}
+		instances = append(instances, &instance)
+	}
+
+	// 更新缓存
+	if r.cfg.EnableCache {
+		r.mu.Lock()
+		r.cache[serviceName] = instances
+		r.mu.Unlock()
+	}
+
+	return instances, nil
+}
+
+// Watch 监听服务实例变化
+func (r *EtcdRegistry) Watch(ctx context.Context, serviceName string) (<-chan types.ServiceEvent, error) {
+	if serviceName == "" {
+		return nil, types.ErrInvalidServiceInstance
+	}
+
+	eventCh := make(chan types.ServiceEvent, 100)
+	prefix := r.buildPrefix(serviceName)
+
+	watchCtx, cancel := context.WithCancel(ctx)
+
+	// 保存 cancel 函数
+	r.mu.Lock()
+	r.watchers[serviceName] = cancel
+	r.mu.Unlock()
+
+	// 启动 watch goroutine
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		defer close(eventCh)
+		defer func() {
+			r.mu.Lock()
+			delete(r.watchers, serviceName)
+			r.mu.Unlock()
+		}()
+
+		watchChan := r.client.Watch(watchCtx, prefix, clientv3.WithPrefix())
+		for {
+			select {
+			case <-watchCtx.Done():
+				return
+			case <-r.stopChan:
+				return
+			case wresp, ok := <-watchChan:
+				if !ok {
+					return
+				}
+				if wresp.Err() != nil {
+					r.logger.Error("watch error",
+						clog.String("service_name", serviceName),
+						clog.Error(wresp.Err()))
+					continue
+				}
+
+				for _, ev := range wresp.Events {
+					var event types.ServiceEvent
+					var instance types.ServiceInstance
+
+					switch ev.Type {
+					case clientv3.EventTypePut:
+						// PUT 事件：反序列化服务实例
+						if err := json.Unmarshal(ev.Kv.Value, &instance); err != nil {
+							r.logger.Warn("failed to unmarshal watch event",
+								clog.Error(err))
+							continue
+						}
+						event = types.ServiceEvent{
+							Type:    types.EventTypePut,
+							Service: &instance,
+						}
+						// 更新缓存
+						if r.cfg.EnableCache {
+							r.updateCache(serviceName, &instance, true)
+						}
+
+					case clientv3.EventTypeDelete:
+						// DELETE 事件：从 key 中提取服务 ID
+						// Key 格式: /namespace/service_name/instance_id
+						keyParts := strings.Split(string(ev.Kv.Key), "/")
+						if len(keyParts) > 0 {
+							instance.ID = keyParts[len(keyParts)-1]
+							instance.Name = serviceName
+						}
+						event = types.ServiceEvent{
+							Type:    types.EventTypeDelete,
+							Service: &instance,
+						}
+						// 更新缓存
+						if r.cfg.EnableCache {
+							r.updateCache(serviceName, &instance, false)
+						}
+					}
+
+					select {
+					case eventCh <- event:
+					case <-watchCtx.Done():
+						return
+					case <-r.stopChan:
+						return
+					}
+				}
+			}
+		}
+	}()
+
+	return eventCh, nil
+}
+
+// GetConnection 获取到指定服务的 gRPC 连接
+func (r *EtcdRegistry) GetConnection(ctx context.Context, serviceName string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	target := fmt.Sprintf("%s:///%s", r.cfg.Schema, serviceName)
+
+	// 添加默认选项
+	defaultOpts := []grpc.DialOption{
+		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	// 合并选项
+	allOpts := append(defaultOpts, opts...)
+
+	conn, err := grpc.DialContext(ctx, target, allOpts...)
+	if err != nil {
+		r.logger.Error("failed to create grpc connection",
+			clog.String("service_name", serviceName),
+			clog.Error(err))
+		return nil, fmt.Errorf("dial failed: %w", err)
+	}
+
+	return conn, nil
+}
+
+// Start 启动后台任务
+func (r *EtcdRegistry) Start(ctx context.Context) error {
+	r.logger.Info("starting registry service")
+	return nil
+}
+
+// Stop 停止后台任务并清理资源
+func (r *EtcdRegistry) Stop(ctx context.Context) error {
+	r.logger.Info("stopping registry service")
+
+	close(r.stopChan)
+
+	// 停止所有 watchers
+	r.mu.Lock()
+	for _, cancel := range r.watchers {
+		cancel()
+	}
+	r.watchers = make(map[string]context.CancelFunc)
+
+	// 撤销所有 leases
+	for serviceID, leaseID := range r.leases {
+		if _, err := r.client.Revoke(ctx, leaseID); err != nil {
+			r.logger.Error("failed to revoke lease on stop",
+				clog.String("service_id", serviceID),
+				clog.Error(err))
+		}
+	}
+	r.leases = make(map[string]clientv3.LeaseID)
+	r.mu.Unlock()
+
+	r.wg.Wait()
+
+	r.logger.Info("registry service stopped")
+	return nil
+}
+
+// Phase 返回启动阶段
+func (r *EtcdRegistry) Phase() int {
+	return 20 // 与其他业务组件一致
+}
+
+// keepAlive 保持租约活跃
+func (r *EtcdRegistry) keepAlive(serviceID string, leaseID clientv3.LeaseID) {
+	defer r.wg.Done()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	keepAliveCh, err := r.client.KeepAlive(ctx, leaseID)
+	if err != nil {
+		r.logger.Error("failed to start keepalive",
+			clog.String("service_id", serviceID),
+			clog.Error(err))
+		return
+	}
+
+	for {
+		select {
+		case <-r.stopChan:
+			return
+		case resp, ok := <-keepAliveCh:
+			if !ok {
+				r.logger.Warn("keepalive channel closed",
+					clog.String("service_id", serviceID))
+				return
+			}
+			if resp == nil {
+				r.logger.Warn("keepalive response is nil",
+					clog.String("service_id", serviceID))
+				return
+			}
+		}
+	}
+}
+
+// updateCache 更新缓存
+func (r *EtcdRegistry) updateCache(serviceName string, instance *types.ServiceInstance, isAdd bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	instances, exists := r.cache[serviceName]
+	if !exists {
+		if isAdd {
+			r.cache[serviceName] = []*types.ServiceInstance{instance}
+		}
+		return
+	}
+
+	if isAdd {
+		// 检查是否已存在
+		for i, inst := range instances {
+			if inst.ID == instance.ID {
+				instances[i] = instance // 更新
+				return
+			}
+		}
+		r.cache[serviceName] = append(instances, instance)
+	} else {
+		// 删除
+		newInstances := make([]*types.ServiceInstance, 0, len(instances))
+		for _, inst := range instances {
+			if inst.ID != instance.ID {
+				newInstances = append(newInstances, inst)
+			}
+		}
+		r.cache[serviceName] = newInstances
+	}
+}
+
+// buildKey 构建服务实例的完整 key
+func (r *EtcdRegistry) buildKey(serviceName, instanceID string) string {
+	return fmt.Sprintf("%s/%s/%s", r.cfg.Namespace, serviceName, instanceID)
+}
+
+// buildPrefix 构建服务的前缀
+func (r *EtcdRegistry) buildPrefix(serviceName string) string {
+	return fmt.Sprintf("%s/%s/", r.cfg.Namespace, serviceName)
+}

--- a/internal/registry/etcd/resolver.go
+++ b/internal/registry/etcd/resolver.go
@@ -1,0 +1,174 @@
+package etcd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ceyewan/genesis/pkg/clog"
+	"github.com/ceyewan/genesis/pkg/registry/types"
+	"google.golang.org/grpc/resolver"
+)
+
+// etcdResolverBuilder 实现 gRPC resolver.Builder 接口
+type etcdResolverBuilder struct {
+	registry *EtcdRegistry
+	scheme   string
+}
+
+// newEtcdResolverBuilder 创建 resolver builder
+func newEtcdResolverBuilder(registry *EtcdRegistry, scheme string) *etcdResolverBuilder {
+	return &etcdResolverBuilder{
+		registry: registry,
+		scheme:   scheme,
+	}
+}
+
+// Build 创建 resolver
+func (b *etcdResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	serviceName := target.Endpoint()
+	if serviceName == "" {
+		serviceName = target.URL.Path
+		serviceName = strings.TrimPrefix(serviceName, "/")
+	}
+
+	r := &etcdResolver{
+		registry:    b.registry,
+		serviceName: serviceName,
+		cc:          cc,
+		closeCh:     make(chan struct{}),
+	}
+
+	// 启动 resolver
+	go r.start()
+
+	return r, nil
+}
+
+// Scheme 返回 scheme
+func (b *etcdResolverBuilder) Scheme() string {
+	return b.scheme
+}
+
+// etcdResolver 实现 gRPC resolver.Resolver 接口
+type etcdResolver struct {
+	registry    *EtcdRegistry
+	serviceName string
+	cc          resolver.ClientConn
+	closeCh     chan struct{}
+}
+
+// start 启动 resolver
+func (r *etcdResolver) start() {
+	ctx := context.Background()
+
+	// 监听服务变化
+	eventCh, err := r.registry.Watch(ctx, r.serviceName)
+	if err != nil {
+		r.registry.logger.Error("failed to watch service for resolver",
+			clog.String("service_name", r.serviceName),
+			clog.Error(err))
+		return
+	}
+
+	// 初始获取服务列表
+	r.updateAddresses()
+
+	// 持续监听变化
+	for {
+		select {
+		case <-r.closeCh:
+			return
+		case event, ok := <-eventCh:
+			if !ok {
+				return
+			}
+			// 收到事件后更新地址列表
+			_ = event // 忽略具体事件，直接重新获取完整列表
+			r.updateAddresses()
+		}
+	}
+}
+
+// updateAddresses 更新地址列表
+func (r *etcdResolver) updateAddresses() {
+	ctx := context.Background()
+	instances, err := r.registry.GetService(ctx, r.serviceName)
+	if err != nil {
+		r.registry.logger.Error("failed to get service for resolver",
+			clog.String("service_name", r.serviceName),
+			clog.Error(err))
+		return
+	}
+
+	var addrs []resolver.Address
+	for _, instance := range instances {
+		for _, endpoint := range instance.Endpoints {
+			// 解析 endpoint (格式: grpc://host:port 或 host:port)
+			addr := parseEndpoint(endpoint)
+			if addr != "" {
+				addrs = append(addrs, resolver.Address{
+					Addr:       addr,
+					ServerName: instance.Name,
+					Attributes: nil,
+				})
+			}
+		}
+	}
+
+	// 更新 gRPC 连接状态
+	// 如果地址列表为空，不更新状态（可能是服务全部下线或程序退出）
+	if len(addrs) == 0 {
+		r.registry.logger.Warn("no available service instances",
+			clog.String("service_name", r.serviceName))
+		return
+	}
+
+	state := resolver.State{
+		Addresses: addrs,
+	}
+
+	if err := r.cc.UpdateState(state); err != nil {
+		r.registry.logger.Error("failed to update resolver state",
+			clog.String("service_name", r.serviceName),
+			clog.Error(err))
+	}
+}
+
+// ResolveNow 立即重新解析（gRPC 可能会调用此方法）
+func (r *etcdResolver) ResolveNow(opts resolver.ResolveNowOptions) {
+	r.updateAddresses()
+}
+
+// Close 关闭 resolver
+func (r *etcdResolver) Close() {
+	close(r.closeCh)
+}
+
+// parseEndpoint 解析 endpoint 地址
+// 支持格式: grpc://host:port, http://host:port, host:port
+func parseEndpoint(endpoint string) string {
+	// 移除协议前缀
+	endpoint = strings.TrimPrefix(endpoint, "grpc://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+
+	return endpoint
+}
+
+// serviceInstanceToAddresses 将服务实例转换为 gRPC 地址列表
+func serviceInstanceToAddresses(instances []*types.ServiceInstance) []resolver.Address {
+	var addrs []resolver.Address
+	for _, instance := range instances {
+		for _, endpoint := range instance.Endpoints {
+			addr := parseEndpoint(endpoint)
+			if addr != "" {
+				addrs = append(addrs, resolver.Address{
+					Addr:       addr,
+					ServerName: instance.Name,
+					Attributes: nil,
+				})
+			}
+		}
+	}
+	return addrs
+}

--- a/pkg/registry/options.go
+++ b/pkg/registry/options.go
@@ -1,0 +1,47 @@
+package registry
+
+import (
+	"github.com/ceyewan/genesis/pkg/clog"
+	telemetrytypes "github.com/ceyewan/genesis/pkg/telemetry/types"
+)
+
+// Option 组件初始化选项函数
+type Option func(*options)
+
+// options 选项结构
+type options struct {
+	logger clog.Logger
+	meter  telemetrytypes.Meter
+	tracer telemetrytypes.Tracer
+}
+
+// WithLogger 注入日志记录器
+// 组件内部会自动追加 "registry" namespace
+func WithLogger(l clog.Logger) Option {
+	return func(o *options) {
+		if l != nil {
+			o.logger = l.WithNamespace("registry")
+		}
+	}
+}
+
+// WithMeter 注入指标 Meter
+func WithMeter(m telemetrytypes.Meter) Option {
+	return func(o *options) {
+		o.meter = m
+	}
+}
+
+// WithTracer 注入 Tracer
+func WithTracer(t telemetrytypes.Tracer) Option {
+	return func(o *options) {
+		o.tracer = t
+	}
+}
+
+// defaultOptions 返回默认选项
+func defaultOptions() *options {
+	return &options{
+		logger: clog.Default(),
+	}
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,0 +1,47 @@
+package registry
+
+import (
+	internalregistry "github.com/ceyewan/genesis/internal/registry/etcd"
+	"github.com/ceyewan/genesis/pkg/connector"
+	"github.com/ceyewan/genesis/pkg/registry/types"
+)
+
+// 重新导出类型，方便使用
+type (
+	Registry        = types.Registry
+	ServiceInstance = types.ServiceInstance
+	ServiceEvent    = types.ServiceEvent
+	EventType       = types.EventType
+	Config          = types.Config
+)
+
+// 重新导出常量
+const (
+	EventTypePut    = types.EventTypePut
+	EventTypeDelete = types.EventTypeDelete
+)
+
+// 重新导出错误
+var (
+	ErrServiceNotFound          = types.ErrServiceNotFound
+	ErrServiceAlreadyRegistered = types.ErrServiceAlreadyRegistered
+	ErrInvalidServiceInstance   = types.ErrInvalidServiceInstance
+	ErrLeaseExpired             = types.ErrLeaseExpired
+	ErrWatchClosed              = types.ErrWatchClosed
+	ErrConnectionFailed         = types.ErrConnectionFailed
+)
+
+// New 创建 Registry 实例（基于 Etcd）
+// conn: Etcd 连接器
+// cfg: 组件配置
+// opts: 可选参数 (Logger, Meter, Tracer)
+func New(conn connector.EtcdConnector, cfg Config, opts ...Option) (Registry, error) {
+	// 应用选项
+	opt := defaultOptions()
+	for _, o := range opts {
+		o(opt)
+	}
+
+	// 调用内部实现
+	return internalregistry.New(conn, cfg, opt.logger, opt.meter, opt.tracer)
+}

--- a/pkg/registry/types/config.go
+++ b/pkg/registry/types/config.go
@@ -1,0 +1,24 @@
+package types
+
+import "time"
+
+// Config Registry 组件配置
+type Config struct {
+	// Namespace Etcd Key 前缀，默认 "/genesis/services"
+	Namespace string `yaml:"namespace" json:"namespace"`
+
+	// Schema 注册到 gRPC resolver 的 schema，默认 "etcd"
+	Schema string `yaml:"schema" json:"schema"`
+
+	// DefaultTTL 默认服务注册租约时长，默认 30s
+	DefaultTTL time.Duration `yaml:"default_ttl" json:"default_ttl"`
+
+	// RetryInterval 重连/重试间隔，默认 1s
+	RetryInterval time.Duration `yaml:"retry_interval" json:"retry_interval"`
+
+	// EnableCache 是否启用本地服务发现缓存，默认 true
+	EnableCache bool `yaml:"enable_cache" json:"enable_cache"`
+
+	// CacheExpiration 本地缓存过期时间，默认 10s
+	CacheExpiration time.Duration `yaml:"cache_expiration" json:"cache_expiration"`
+}

--- a/pkg/registry/types/errors.go
+++ b/pkg/registry/types/errors.go
@@ -1,0 +1,23 @@
+package types
+
+import "errors"
+
+var (
+	// ErrServiceNotFound 服务未找到
+	ErrServiceNotFound = errors.New("service not found")
+
+	// ErrServiceAlreadyRegistered 服务已注册
+	ErrServiceAlreadyRegistered = errors.New("service already registered")
+
+	// ErrInvalidServiceInstance 无效的服务实例
+	ErrInvalidServiceInstance = errors.New("invalid service instance")
+
+	// ErrLeaseExpired 租约已过期
+	ErrLeaseExpired = errors.New("lease expired")
+
+	// ErrWatchClosed Watch 已关闭
+	ErrWatchClosed = errors.New("watch closed")
+
+	// ErrConnectionFailed 连接失败
+	ErrConnectionFailed = errors.New("connection failed")
+)

--- a/pkg/registry/types/interface.go
+++ b/pkg/registry/types/interface.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// Registry 服务注册与发现接口
+type Registry interface {
+	// --- 服务注册 ---
+
+	// Register 注册服务实例
+	// ctx: 上下文
+	// service: 服务实例信息
+	// ttl: 租约有效期 (例如 10s)，超时后若无续约服务将自动下线
+	Register(ctx context.Context, service *ServiceInstance, ttl time.Duration) error
+
+	// Deregister 注销服务实例
+	// serviceID: 服务实例 ID
+	Deregister(ctx context.Context, serviceID string) error
+
+	// --- 服务发现 ---
+
+	// GetService 获取服务实例列表
+	// 优先读取本地缓存，缓存未命中或过期时查询注册中心
+	GetService(ctx context.Context, serviceName string) ([]*ServiceInstance, error)
+
+	// Watch 监听服务实例变化
+	// 返回一个事件通道，接收服务变化事件 (PUT/DELETE)
+	Watch(ctx context.Context, serviceName string) (<-chan ServiceEvent, error)
+
+	// --- gRPC 集成 ---
+
+	// GetConnection 获取到指定服务的 gRPC 连接
+	// 内部封装了 Resolver 和 Balancer 的配置，提供开箱即用的连接对象
+	// 支持自动服务发现和客户端负载均衡
+	GetConnection(ctx context.Context, serviceName string, opts ...grpc.DialOption) (*grpc.ClientConn, error)
+
+	// --- 生命周期管理 ---
+
+	// Start 启动后台任务 (Lease KeepAlive、Watch 监听等)
+	Start(ctx context.Context) error
+
+	// Stop 停止后台任务并清理资源
+	Stop(ctx context.Context) error
+
+	// Phase 返回启动阶段 (建议 20，与其他业务组件一致)
+	Phase() int
+}
+
+// ServiceEvent 服务变化事件
+type ServiceEvent struct {
+	Type    EventType        // 事件类型 (PUT/DELETE)
+	Service *ServiceInstance // 服务实例信息
+}
+
+// EventType 事件类型
+type EventType string
+
+const (
+	EventTypePut    EventType = "PUT"    // 服务注册或更新
+	EventTypeDelete EventType = "DELETE" // 服务注销
+)

--- a/pkg/registry/types/service.go
+++ b/pkg/registry/types/service.go
@@ -1,0 +1,10 @@
+package types
+
+// ServiceInstance 代表一个服务实例
+type ServiceInstance struct {
+	ID        string            `json:"id"`        // 唯一实例 ID (通常是 UUID)
+	Name      string            `json:"name"`      // 服务名称 (如 user-service)
+	Version   string            `json:"version"`   // 版本号
+	Metadata  map[string]string `json:"metadata"`  // 元数据 (Region, Zone, Weight, Group 等)
+	Endpoints []string          `json:"endpoints"` // 服务地址列表 (如 grpc://192.168.1.10:9090)
+}


### PR DESCRIPTION
- 实现服务注册核心功能，支持自动续约和租约管理
- 实现服务发现功能，支持实时监听和本地缓存
- 集成 gRPC Resolver，支持客户端负载均衡
- 提供标准的生命周期管理接口（Start/Stop）
- 添加完整的设计文档和使用示例
- 新增基础服务注册示例和 gRPC 集成示例