### PR TITLE
refactor(config): 重构 API 设计，参考 clog 统一风格

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,25 +1,46 @@
 package config
 
-import (
-	"context"
-)
-
 // New 创建一个新的配置加载器实例
-func New(opts ...Option) (Loader, error) {
-	return newLoader(opts...)
-}
-
-// MustLoad 创建 Loader 实例并立即加载配置，出错时 panic（仅用于初始化）
-func MustLoad(opts ...Option) Loader {
-	loader, err := New(opts...)
-	if err != nil {
-		panic(err)
+//
+// config 为配置，opts 为函数式选项。
+//
+// 基本使用：
+//
+//	loader, _ := config.New(&config.Config{
+//	    Name:     "config",
+//	    FileType: "yaml",
+//	})
+//
+// 使用选项：
+//
+//	loader, _ := config.New(&config.Config{},
+//	    config.WithConfigName("app"),
+//	    config.WithConfigPath("/etc/app"),
+//	)
+//
+// 参数：
+//
+//	config - 配置，如果为 nil 会使用默认配置
+//	opts   - 函数式选项列表，用于覆盖配置
+//
+// 返回：
+//
+//	Loader - 配置加载器
+//	error  - 配置验证错误
+func New(cfg *Config, opts ...Option) (Loader, error) {
+	if cfg == nil {
+		cfg = &Config{}
 	}
 
-	ctx := context.Background()
-	if err := loader.Load(ctx); err != nil {
-		panic(err)
+	// 应用选项
+	for _, opt := range opts {
+		opt(cfg)
 	}
 
-	return loader
+	// 验证配置
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	return newLoader(cfg)
 }

--- a/config/options.go
+++ b/config/options.go
@@ -1,72 +1,65 @@
 package config
 
 // Option 配置选项模式
-type Option func(*Options)
+type Option func(*Config)
 
-type Options struct {
-	Name       string   // 配置文件名称（不含扩展名）
-	Paths      []string // 配置文件搜索路径
-	FileType   string   // 配置文件类型 (yaml, json, etc.)
-	EnvPrefix  string   // 环境变量前缀
-	RemoteOpts *RemoteOptions
+// Config 配置结构
+type Config struct {
+	Name      string   // 配置文件名称（不含扩展名）
+	Paths     []string // 配置文件搜索路径
+	FileType  string   // 配置文件类型 (yaml, json, etc.)
+	EnvPrefix string   // 环境变量前缀
 }
 
-type RemoteOptions struct {
-	Provider string // 远程提供者 (etcd, consul, etc.)
-	Endpoint string // 远程端点
+// validate 设置默认值并验证配置
+func (c *Config) validate() error {
+	// 设置默认值
+	if c.Name == "" {
+		c.Name = "config"
+	}
+	if c.Paths == nil {
+		c.Paths = []string{".", "./config"}
+	}
+	if c.FileType == "" {
+		c.FileType = "yaml"
+	}
+	if c.EnvPrefix == "" {
+		c.EnvPrefix = "GENESIS"
+	}
+	return nil
 }
 
 // WithConfigName 设置配置文件名称（不带扩展名）
 func WithConfigName(name string) Option {
-	return func(o *Options) {
-		o.Name = name
+	return func(c *Config) {
+		c.Name = name
 	}
 }
 
 // WithConfigPath 添加配置文件搜索路径
 func WithConfigPath(path string) Option {
-	return func(o *Options) {
-		o.Paths = append(o.Paths, path)
+	return func(c *Config) {
+		c.Paths = append(c.Paths, path)
 	}
 }
 
 // WithConfigPaths 设置配置文件搜索路径（覆盖默认值）
 func WithConfigPaths(paths ...string) Option {
-	return func(o *Options) {
-		o.Paths = paths
+	return func(c *Config) {
+		c.Paths = paths
 	}
 }
 
 // WithConfigType 设置配置文件类型 (yaml, json, etc.)
 func WithConfigType(typ string) Option {
-	return func(o *Options) {
-		o.FileType = typ
+	return func(c *Config) {
+		c.FileType = typ
 	}
 }
 
 // WithEnvPrefix 设置环境变量前缀
 func WithEnvPrefix(prefix string) Option {
-	return func(o *Options) {
-		o.EnvPrefix = prefix
-	}
-}
-
-// WithRemote 设置远程配置中心选项
-func WithRemote(provider, endpoint string) Option {
-	return func(o *Options) {
-		o.RemoteOpts = &RemoteOptions{
-			Provider: provider,
-			Endpoint: endpoint,
-		}
-	}
-}
-
-// defaultOptions 返回默认选项
-func defaultOptions() *Options {
-	return &Options{
-		Name:      "config",
-		Paths:     []string{".", "./config"},
-		FileType:  "yaml",
-		EnvPrefix: "GENESIS",
+	return func(c *Config) {
+		c.EnvPrefix = prefix
 	}
 }

--- a/config/viper_test.go
+++ b/config/viper_test.go
@@ -66,12 +66,12 @@ GENESIS_CLOG_FORMAT=json
 	}()
 
 	ctx := context.Background()
-	loader, err := New(
-		WithConfigName("config"),
-		WithConfigPaths(tmpDir),
-		WithConfigType("yaml"),
-		WithEnvPrefix("GENESIS"),
-	)
+	loader, err := New(&Config{
+		Name:     "config",
+		Paths:    []string{tmpDir},
+		FileType: "yaml",
+		EnvPrefix: "GENESIS",
+	})
 	if err != nil {
 		t.Fatalf("Failed to create loader: %v", err)
 	}
@@ -130,20 +130,20 @@ func TestLoaderValidate(t *testing.T) {
 				if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
 					return nil, err
 				}
-				return New(
-					WithConfigName("config"),
-					WithConfigPaths(tmpDir),
-				)
+				return New(&Config{
+					Name:  "config",
+					Paths: []string{tmpDir},
+				})
 			},
 			wantErr: false,
 		},
 		{
 			name: "empty config",
 			setupLoader: func() (Loader, error) {
-				return New(
-					WithConfigName("nonexistent"),
-					WithConfigPaths("/nonexistent"),
-				)
+				return New(&Config{
+					Name:  "nonexistent",
+					Paths: []string{"/nonexistent"},
+				})
 			},
 			wantErr: true,
 		},
@@ -188,11 +188,11 @@ test:
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	loader, err := New(
-		WithConfigName("watch-test"),
-		WithConfigPaths(tmpDir),
-		WithConfigType("yaml"),
-	)
+	loader, err := New(&Config{
+		Name:     "watch-test",
+		Paths:    []string{tmpDir},
+		FileType: "yaml",
+	})
 	if err != nil {
 		t.Fatalf("Failed to create loader: %v", err)
 	}
@@ -283,10 +283,10 @@ func TestLoaderWatchCancel(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	loader, err := New(
-		WithConfigName("cancel-test"),
-		WithConfigPaths(tmpDir),
-	)
+	loader, err := New(&Config{
+		Name:  "cancel-test",
+		Paths: []string{tmpDir},
+	})
 	if err != nil {
 		t.Fatalf("Failed to create loader: %v", err)
 	}
@@ -329,10 +329,10 @@ func TestLoaderMultipleWatches(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	loader, err := New(
-		WithConfigName("multi-watch"),
-		WithConfigPaths(tmpDir),
-	)
+	loader, err := New(&Config{
+		Name:  "multi-watch",
+		Paths: []string{tmpDir},
+	})
 	if err != nil {
 		t.Fatalf("Failed to create loader: %v", err)
 	}
@@ -412,11 +412,11 @@ func TestLoaderEnvLoading(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	loader, err := New(
-		WithConfigName("config"),
-		WithConfigPaths("./nonexistent"), // 配置文件不存在，只使用环境变量
-		WithEnvPrefix("TEST"),
-	)
+	loader, err := New(&Config{
+		Name:      "config",
+		Paths:     []string{"./nonexistent"}, // 配置文件不存在，只使用环境变量
+		EnvPrefix: "TEST",
+	})
 	if err != nil {
 		t.Fatalf("Failed to create loader: %v", err)
 	}

--- a/examples/config/main.go
+++ b/examples/config/main.go
@@ -93,12 +93,12 @@ func basicConfigExample() {
 	ctx := context.Background()
 
 	// 创建配置加载器
-	loader, err := config.New(
-		config.WithConfigName("config"),
-		config.WithConfigPath("./config"),
-		config.WithConfigType("yaml"),
-		config.WithEnvPrefix("GENESIS"),
-	)
+	loader, err := config.New(&config.Config{
+		Name:      "config",
+		Paths:     []string{"./config"},
+		FileType:  "yaml",
+		EnvPrefix: "GENESIS",
+	})
 	if err != nil {
 		log.Fatalf("创建配置加载器失败: %v", err)
 	}
@@ -164,12 +164,12 @@ func usageExamples() {
 
 	ctx := context.Background()
 
-	loader, err := config.New(
-		config.WithConfigName("config"),
-		config.WithConfigPath("./config"),
-		config.WithConfigType("yaml"),
-		config.WithEnvPrefix("GENESIS"),
-	)
+	loader, err := config.New(&config.Config{
+		Name:      "config",
+		Paths:     []string{"./config"},
+		FileType:  "yaml",
+		EnvPrefix: "GENESIS",
+	})
 	if err != nil {
 		log.Fatalf("创建配置加载器失败: %v", err)
 	}
@@ -237,12 +237,12 @@ func configWatchExample() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	loader, err := config.New(
-		config.WithConfigName("config"),
-		config.WithConfigPath("./config"),
-		config.WithConfigType("yaml"),
-		config.WithEnvPrefix("GENESIS"),
-	)
+	loader, err := config.New(&config.Config{
+		Name:      "config",
+		Paths:     []string{"./config"},
+		FileType:  "yaml",
+		EnvPrefix: "GENESIS",
+	})
 	if err != nil {
 		log.Fatalf("创建配置加载器失败: %v", err)
 	}


### PR DESCRIPTION
- Options → Config 重命名，更直观
- 删除 MustLoad 函数，不鼓励 panic 用法
- New 签名改为 New(cfg *Config, opts ...Option)，与 clog 保持一致
- Config 增加 validate() 方法处理默认值
- 修复 .env 热加载使用 Overload 替代 Load
- 删除误导性的 WithRemote API（保留扩展能力）
- 支持空 Config 自动降级为默认配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)