### PR TITLE
feat(idgen): 为 Sequencer 添加 Set 和 SetIfNotExists 方法

### DIFF
--- a/idgen/idgen.go
+++ b/idgen/idgen.go
@@ -50,6 +50,14 @@ type Sequencer interface {
 
 	// NextBatch 为指定键批量生成序列号
 	NextBatch(ctx context.Context, key string, count int) ([]int64, error)
+
+	// Set 直接设置序列号的值
+	// 警告：此操作会覆盖现有值，请谨慎使用
+	Set(ctx context.Context, key string, value int64) error
+
+	// SetIfNotExists 仅当键不存在时设置序列号的值
+	// 返回 true 表示设置成功，false 表示键已存在
+	SetIfNotExists(ctx context.Context, key string, value int64) (bool, error)
 }
 
 // ========================================


### PR DESCRIPTION
## 概述

为 `idgen.Sequencer` 接口添加 `Set` 和 `SetIfNotExists` 方法，解决 issue #27 中描述的序列号初始化需求。

## 变更内容

### 接口变更 ([idgen.go](idgen/idgen.go))
```go
type Sequencer interface {
    Next(ctx context.Context, key string) (int64, error)
    NextBatch(ctx context.Context, key string, count int) ([]int64, error)
    
    // 新增：
    Set(ctx context.Context, key string, value int64) error
    SetIfNotExists(ctx context.Context, key string, value int64) (bool, error)
}
```

### 实现细节 ([sequence.go](idgen/sequence.go))
- `Set`: 直接设置序列号值，使用 Redis `SET` 命令，会覆盖现有值
- `SetIfNotExists`: 仅当键不存在时设置，使用 Redis `SETNX` 命令，返回 bool 表示是否设置成功
- 两个方法均对负值进行校验，返回 `ErrInvalidInput` 错误
- 完整的日志记录（Debug 和 Error 级别）

### 测试覆盖 ([idgen_test.go](idgen/idgen_test.go))
- `TestSequencer_Set`: 基本设置、负值校验、覆盖行为、前缀处理
- `TestSequencer_SetIfNotExists`: 新键设置、已存在键处理、负值校验、IM 场景模拟

## 使用场景

IM 系统中会话消息序列号初始化：
```go
// 安全初始化：仅在首次部署时设置起始值
ok, err := sequencer.SetIfNotExists(ctx, "conversation:123", 100)
if err != nil { /* 处理错误 */ }
if !ok {
    // 键已存在，可能是其他进程已初始化
}

// 后续正常递增
seq, _ := sequencer.Next(ctx, "conversation:123") // 101
```

## 测试

所有测试通过：
```
go test -v ./idgen/
PASS
ok  	github.com/ceyewan/genesis/idgen	0.434s
```

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)