### PR TITLE
fix(v1): finalize rc validation

### DIFF
--- a/connector/integration_test.go
+++ b/connector/integration_test.go
@@ -13,12 +13,14 @@ import (
 
 	natsgo "github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
 	tcetcd "github.com/testcontainers/testcontainers-go/modules/etcd"
 	"github.com/testcontainers/testcontainers-go/modules/kafka"
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
 	"github.com/testcontainers/testcontainers-go/modules/nats"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/modules/redis"
+	"github.com/testcontainers/testcontainers-go/wait"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"gorm.io/gorm"
 
@@ -175,6 +177,9 @@ func setupMySQLContainer(t *testing.T) (*mysql.MySQLContainer, *MySQLConfig) {
 		mysql.WithDatabase("genesis_db"),
 		mysql.WithUsername("genesis_user"),
 		mysql.WithPassword("genesis_password"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("port: 3306  MySQL Community Server").WithStartupTimeout(2*time.Minute),
+		),
 	)
 	require.NoError(t, err, "Failed to start MySQL container")
 

--- a/docs/v1-rc1-evidence.md
+++ b/docs/v1-rc1-evidence.md
@@ -1,12 +1,13 @@
 # Genesis v1.0.0-rc.1 verification evidence
 
-This record describes the local and GitHub-hosted candidate verification performed on 2026-08-09. The candidate is published through draft PR [#58](https://github.com/ceyewan/genesis/pull/58). No tag, GitHub Release, or deployment has been created.
+This record describes the local and GitHub-hosted candidate verification performed on 2026-08-09. PR [#58](https://github.com/ceyewan/genesis/pull/58) was merged through the protected branch into `main`; its merge commit was `c80babaf35f71d656b85e28b8ae02a54e06ce7ce`. No tag, GitHub Release, or deployment has been created.
 
 ## Environment
 
 - Go: `go1.26.1 darwin/arm64`
 - Docker client/server: `29.4.0` / `29.4.0`
-- Remediation baseline: `48acd69eea91764bc8452ea3f55dfe7a2a027607`
+- Original remediation baseline: `48acd69eea91764bc8452ea3f55dfe7a2a027607`
+- Final pre-RC audit baseline: `c80babaf35f71d656b85e28b8ae02a54e06ce7ce`
 - Scope: all 18 externally importable packages, plus examples and internal API-inventory tooling
 
 ## Full local gates
@@ -31,6 +32,8 @@ git diff --check
 
 The ordinary and race suites executed real Docker/Testcontainers dependencies rather than skipping them. They covered Redis, etcd, PostgreSQL, MySQL, NATS JetStream, and Kafka. Connector tests took about 60 seconds in both suites; registry, dlock, DB, MQ, idem, idgen, and ratelimit also ran their container-backed cases. `make example-all` exited successfully without a separately started development stack: local examples ran normally, while external-service examples reported their documented classifiable connection failures or skips. Successful external paths are covered by Testcontainers.
 
+An independent rerun against `c80baba` exposed a concurrent local race-suite readiness failure: MySQL exceeded the module's default 60-second startup wait and three JetStream tests consumed their five-second business contexts while starting NATS containers. The remediation represented by this record starts MQ operation contexts only after container/connector initialization and gives MySQL an explicit two-minute startup wait. The exact non-serialized commands `go test -count=1 ./...` and `go test -race -count=1 ./...` then both passed with all containers executing.
+
 `make godoc-artifacts` generated exactly 18 package artifacts. `make api-inventory-check` passed after regeneration from `internal/cmd/apiinventory`.
 
 ## Directed contract evidence
@@ -46,6 +49,7 @@ The full ordinary and race suites include regression coverage for the audit find
 - Cache/dlock/idgen/ratelimit/trace reject negative public duration configuration instead of silently applying defaults. Cache methods reject negative operation TTLs.
 - Cache/idem/idgen/mq/ratelimit constructors reject unconnected borrowed connectors with errors classifiable as `connector.ErrClientNil`, without panicking.
 - Breaker/ratelimit/idgen: meaningful breaker assertions, bounded key cardinality, fallback results, failure classification, non-serializing rate-limit Wait, terminal Close, typed drivers, composable defaults, and rejecting invalid Snowflake parsing.
+- Idgen sequencer: zero `Step` defaults to one, while a negative `Step` reaches validation and returns `ErrInvalidInput` with `step_must_be_positive`.
 
 ## API and CI audit
 
@@ -56,9 +60,12 @@ The full ordinary and race suites include regression coverage for the audit find
 - `.github/workflows/ci.yml` gates PRs, pushes to `main`, and SemVer tags with separate ordinary/race Testcontainers jobs, exact Go patch and runner versions, commit-pinned Actions, job timeouts, actionlint/module drift checks, build/examples/API/GoDoc checks, exact artifact-count validation, and a release gate depending on every job.
 - A manual pre-tag workflow dispatch takes an exact candidate SHA and proposed SemVer tag, runs the same jobs against that SHA, and must succeed before the tag is created. The tag path revalidates the same identity after creation.
 - Hosted run [31288087305](https://github.com/ceyewan/genesis/actions/runs/31288087305) passed all four required jobs against candidate `76cb23ca6d31fcd6bc4a1d1e59e38de095e2da3e`: ordinary Testcontainers, race Testcontainers, static/API/GoDoc, and build/examples. The release gate was correctly skipped because this was a pull-request run.
+- PR #58's final run [31288491663](https://github.com/ceyewan/genesis/actions/runs/31288491663) passed all four required jobs against `8707620dab42a715a6eb6099f55ae27cecdaa2a1`; the protected merge produced `c80babaf35f71d656b85e28b8ae02a54e06ce7ce`.
+- Final `main` push run [31288717036](https://github.com/ceyewan/genesis/actions/runs/31288717036) passed all four required jobs against exact merge SHA `c80baba`, including ordinary and race Testcontainers artifacts.
+- Exact-SHA pre-tag run [31288875228](https://github.com/ceyewan/genesis/actions/runs/31288875228) passed all core jobs and the release identity gate for proposed tag `v1.0.0-rc.1` at `c80baba`.
 - `main` branch protection requires those four checks on an up-to-date branch, applies to administrators, requires pull requests and resolved conversations, and disallows force pushes and deletion.
 - Controlled negative PR [#59](https://github.com/ceyewan/genesis/pull/59) introduced generated API-inventory drift. Hosted run [31288303160](https://github.com/ceyewan/genesis/actions/runs/31288303160) failed specifically at `Check exported API inventory`, and GitHub reported the PR merge state as `BLOCKED`. The PR was then closed and its remote branch deleted.
-- The commit containing this updated evidence must receive the same complete hosted PR run before it replaces the preceding candidate. After merge, the protected `main` commit must pass its push run and an exact-SHA manual pre-tag dispatch with proposed tag `v1.0.0-rc.1` before tag creation.
+- Independent review nevertheless withheld tag approval after reproducing the negative sequencer-step bug and the local concurrent container flake described above. The commit containing this remediation and evidence must receive a complete hosted PR run, protected merge, `main` push run, and exact-SHA pre-tag dispatch before it replaces `c80baba` as the approved candidate.
 
 ## Accepted v1 boundaries
 
@@ -69,4 +76,4 @@ The full ordinary and race suites include regression coverage for the audit find
 - Dlock exposes ownership loss but does not issue fencing tokens; irreversible downstream writes still require CAS/version fencing.
 - Trace supports system TLS and static OTLP headers, but custom certificate-pool construction remains application/deployment configuration outside Genesis v1.
 
-No unresolved P0/P1 API, correctness, migration, or repository-workflow defect identified by the stage audits remains in this candidate. Required-check enforcement and both positive and negative hosted behavior are proven. Stage one remains pending only until this evidence update passes hosted CI, PR #58 is merged through the protected branch, the resulting exact `main` SHA passes both its push run and pre-tag dispatch, and the external stage goal records that final SHA. Tag and release creation remain separate, explicit actions.
+No unresolved local P0/P1 API, correctness, migration, test-stability, or repository-workflow defect identified by the stage audits remains after this remediation. Required-check enforcement and both positive and negative hosted behavior are proven. Stage one is reopened until this remediation passes the complete protected PR/main/pre-tag sequence and the external stage goal records the resulting exact SHA. Tag and release creation remain separate, explicit actions.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/sony/gobreaker/v2 v2.3.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/etcd v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.40.0
@@ -142,7 +143,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/testcontainers/testcontainers-go v0.40.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/idgen/config.go
+++ b/idgen/config.go
@@ -98,7 +98,7 @@ func (c *SequencerConfig) setDefaults() {
 	if c.Driver == "" {
 		c.Driver = DriverRedis
 	}
-	if c.Step <= 0 {
+	if c.Step == 0 {
 		c.Step = 1
 	}
 }

--- a/idgen/idgen_test.go
+++ b/idgen/idgen_test.go
@@ -474,6 +474,12 @@ func TestSequencerConfig_Unit(t *testing.T) {
 		_, err := NewSequencer(&SequencerConfig{TTL: -time.Second})
 		require.Error(t, err)
 	})
+
+	t.Run("negative step returns error", func(t *testing.T) {
+		_, err := NewSequencer(&SequencerConfig{Step: -1})
+		require.ErrorIs(t, err, ErrInvalidInput)
+		require.ErrorContains(t, err, "step_must_be_positive")
+	})
 }
 
 // ========================================

--- a/mq/integration_test.go
+++ b/mq/integration_test.go
@@ -74,10 +74,10 @@ func waitTimeout(t *testing.T, done <-chan struct{}, timeout time.Duration) {
 }
 
 func TestJetStreamPublishSubscribeIntegration(t *testing.T) {
+	mq := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 5*time.Second)
 	defer cancel()
 
-	mq := newJetStreamMQ(t)
 	subject := uniqueSubject()
 
 	done := make(chan struct{})
@@ -98,10 +98,10 @@ func TestJetStreamPublishSubscribeIntegration(t *testing.T) {
 }
 
 func TestJetStreamHeadersIntegration(t *testing.T) {
+	mq := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 5*time.Second)
 	defer cancel()
 
-	mq := newJetStreamMQ(t)
 	subject := uniqueSubject()
 
 	done := make(chan struct{})
@@ -122,10 +122,10 @@ func TestJetStreamHeadersIntegration(t *testing.T) {
 }
 
 func TestJetStreamQueueGroupIntegration(t *testing.T) {
+	mq := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
 
-	mq := newJetStreamMQ(t)
 	subject := uniqueSubject()
 	group := uniqueGroup()
 
@@ -156,10 +156,10 @@ func TestJetStreamQueueGroupIntegration(t *testing.T) {
 }
 
 func TestJetStreamConsumerIdentityIsScopedByTopicIntegration(t *testing.T) {
+	q := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 15*time.Second)
 	defer cancel()
 
-	q := newJetStreamMQ(t)
 	tests := []struct {
 		name   string
 		option func(string) SubscribeOption
@@ -209,10 +209,10 @@ func TestJetStreamConsumerIdentityIsScopedByTopicIntegration(t *testing.T) {
 }
 
 func TestJetStreamMultiGroupBroadcastIntegration(t *testing.T) {
+	mq := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
 
-	mq := newJetStreamMQ(t)
 	subject := uniqueSubject()
 	groupA := uniqueGroup()
 	groupB := uniqueGroup()
@@ -258,10 +258,10 @@ func TestJetStreamMultiGroupBroadcastIntegration(t *testing.T) {
 }
 
 func TestJetStreamDurableResumeIntegration(t *testing.T) {
+	mq := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
 
-	mq := newJetStreamMQ(t)
 	subject := uniqueSubject()
 	durable := "d-" + testkit.NewID()
 
@@ -297,10 +297,10 @@ func TestJetStreamDurableResumeIntegration(t *testing.T) {
 }
 
 func TestJetStreamManualNakWithDelayRedeliveryIntegration(t *testing.T) {
+	q := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
 
-	q := newJetStreamMQ(t)
 	subject := uniqueSubject()
 	var deliveries atomic.Int32
 	done := make(chan struct{})
@@ -325,9 +325,6 @@ func TestJetStreamManualNakWithDelayRedeliveryIntegration(t *testing.T) {
 }
 
 func TestJetStreamAutoCreateConfigAndPublishAckIntegration(t *testing.T) {
-	ctx, cancel := testkit.NewContext(t, 10*time.Second)
-	defer cancel()
-
 	q := newJetStreamMQWithConfig(t, &JetStreamConfig{
 		AutoCreateStream: true,
 		AckWait:          2 * time.Second,
@@ -338,6 +335,8 @@ func TestJetStreamAutoCreateConfigAndPublishAckIntegration(t *testing.T) {
 		MaxBytes:         1 << 20,
 		Replicas:         1,
 	})
+	ctx, cancel := testkit.NewContext(t, 10*time.Second)
+	defer cancel()
 	subject := uniqueSubject()
 	durable := "d-" + testkit.NewID()
 	done := make(chan struct{})
@@ -375,14 +374,13 @@ func TestJetStreamAutoCreateConfigAndPublishAckIntegration(t *testing.T) {
 }
 
 func TestJetStreamMaxDeliverIntegration(t *testing.T) {
-	ctx, cancel := testkit.NewContext(t, 10*time.Second)
-	defer cancel()
-
 	q := newJetStreamMQWithConfig(t, &JetStreamConfig{
 		AutoCreateStream: true,
 		AckWait:          100 * time.Millisecond,
 		MaxDeliver:       3,
 	})
+	ctx, cancel := testkit.NewContext(t, 10*time.Second)
+	defer cancel()
 	subject := uniqueSubject()
 	var deliveries atomic.Int32
 	third := make(chan struct{})
@@ -402,10 +400,10 @@ func TestJetStreamMaxDeliverIntegration(t *testing.T) {
 }
 
 func TestJetStreamMaxInflightBackpressureIntegration(t *testing.T) {
+	q := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
 
-	q := newJetStreamMQ(t)
 	subject := uniqueSubject()
 	firstStarted := make(chan struct{})
 	secondStarted := make(chan struct{})
@@ -436,10 +434,10 @@ func TestJetStreamMaxInflightBackpressureIntegration(t *testing.T) {
 }
 
 func TestJetStreamDrainWaitsForHandlerIntegration(t *testing.T) {
+	q := newJetStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
 
-	q := newJetStreamMQ(t)
 	subject := uniqueSubject()
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -469,9 +467,9 @@ func TestJetStreamDrainWaitsForHandlerIntegration(t *testing.T) {
 }
 
 func TestRedisStreamDefaultStartConsumesRetainedMessages(t *testing.T) {
+	q := newRedisStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
-	q := newRedisStreamMQ(t)
 	topic := uniqueSubject()
 	require.NoError(t, q.Publish(ctx, topic, []byte("before-subscribe")))
 	done := make(chan struct{})
@@ -486,9 +484,9 @@ func TestRedisStreamDefaultStartConsumesRetainedMessages(t *testing.T) {
 }
 
 func TestRedisStreamFromLatestSkipsRetainedMessages(t *testing.T) {
+	q := newRedisStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
-	q := newRedisStreamMQ(t)
 	topic := uniqueSubject()
 	require.NoError(t, q.Publish(ctx, topic, []byte("old")))
 	done := make(chan string, 1)
@@ -508,10 +506,10 @@ func TestRedisStreamFromLatestSkipsRetainedMessages(t *testing.T) {
 }
 
 func TestRedisStreamDrainPreservesActiveHandlerContext(t *testing.T) {
+	q := newRedisStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
 
-	q := newRedisStreamMQ(t)
 	topic := uniqueSubject()
 	handlerContext := make(chan context.Context, 1)
 	release := make(chan struct{})
@@ -537,10 +535,10 @@ func TestRedisStreamDrainPreservesActiveHandlerContext(t *testing.T) {
 }
 
 func TestRedisStreamDrainDeadlineCancelsActiveHandler(t *testing.T) {
+	q := newRedisStreamMQ(t)
 	ctx, cancel := testkit.NewContext(t, 10*time.Second)
 	defer cancel()
 
-	q := newRedisStreamMQ(t)
 	topic := uniqueSubject()
 	handlerStarted := make(chan struct{})
 	handlerDone := make(chan error, 1)
@@ -562,10 +560,10 @@ func TestRedisStreamDrainDeadlineCancelsActiveHandler(t *testing.T) {
 }
 
 func TestJetStreamReconnectAndResumeIntegration(t *testing.T) {
+	container, natsCfg := testkit.NewNATSContainer(t)
 	ctx, cancel := testkit.NewContext(t, 20*time.Second)
 	defer cancel()
 
-	container, natsCfg := testkit.NewNATSContainer(t)
 	natsCfg.MaxReconnects = 100
 	natsCfg.ReconnectWait = 50 * time.Millisecond
 	natsCfg.PingInterval = 100 * time.Millisecond

--- a/testkit/mysql.go
+++ b/testkit/mysql.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
+	"github.com/testcontainers/testcontainers-go/wait"
 	"gorm.io/gorm"
 
 	"github.com/ceyewan/genesis/connector"
@@ -26,6 +28,9 @@ func NewMySQLContainerConfig(t *testing.T) *connector.MySQLConfig {
 		mysql.WithDatabase("genesis_db"),
 		mysql.WithUsername("genesis_user"),
 		mysql.WithPassword("genesis_password"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("port: 3306  MySQL Community Server").WithStartupTimeout(2*time.Minute),
+		),
 	)
 	require.NoError(t, err, "failed to start MySQL container")
 


### PR DESCRIPTION
## Summary

- reject negative idgen sequencer steps while preserving the zero-value default
- start MQ business deadlines after Testcontainers initialization and extend MySQL startup readiness to two minutes
- reconcile the repository RC evidence with PR #58, final main/pre-tag runs, and the reopened final audit

## Local verification

- `go test -count=1 ./...`
- `go test -race -count=1 ./...` (default package parallelism; no `-p=1`)
- `go build ./...`
- `make examples-check && make example-all`
- `make lint && make exported-comments && make modernize-check && make buf-lint`
- `make api-inventory && make api-inventory-check && make godoc-artifacts`
- `git diff --check`

No tag or Release is created by this PR.