### PR TITLE
test(v1): harden rc1 consumer contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > 一个面向 Go 微服务的轻量组件库，而不是框架。
 
+当前已发布预发行基线为
+[`v1.0.0-rc.1`](https://github.com/ceyewan/genesis/releases/tag/v1.0.0-rc.1)，
+tag 指向 `ec5ad2c31fb4adce2bd42529e3d7fbfe92b23aa7`。后续测试和文档提交不会
+自动产生新版本；生产修复需要独立的 `rc.2` 决策与完整发布门禁。
+
 Genesis 提供一组可以直接组合的基础设施与治理组件，目标不是接管应用，而是把日志、配置、连接管理、缓存、分布式锁、消息、认证、限流、熔断、注册发现等通用能力沉淀成统一积木。
 
 项目的核心约束只有三条：
@@ -108,6 +113,7 @@ make example-<component>
 - [组件设计文档索引](docs/README.md)
 - [示例索引](examples/README.md)
 - [测试指南](testkit/README.md)
+- [v1.0.0-rc.1 契约加固与消费者风险清单](docs/v1-rc1-contract-hardening.md)
 
 ## License
 

--- a/connector/rc1_consumer_contract_test.go
+++ b/connector/rc1_consumer_contract_test.go
@@ -1,0 +1,194 @@
+// Package contract_test exercises the v1.0.0-rc.1 surface exactly as an
+// external consumer sees it. The protected behavior is sourced from
+// docs/v1-api-decisions.md and the Resonance integration call sites.
+package connector_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/ceyewan/genesis/auth"
+	"github.com/ceyewan/genesis/cache"
+	"github.com/ceyewan/genesis/config"
+	"github.com/ceyewan/genesis/connector"
+	"github.com/ceyewan/genesis/db"
+	"github.com/ceyewan/genesis/metrics"
+	"github.com/ceyewan/genesis/mq"
+	"github.com/ceyewan/genesis/ratelimit"
+	genesistrace "github.com/ceyewan/genesis/trace"
+)
+
+func TestRC1ConsumerConstructorsRejectNilConfiguration(t *testing.T) {
+	tests := []struct {
+		name      string
+		construct func() error
+		class     error
+	}{
+		{name: "auth", construct: func() error { _, err := auth.New(nil); return err }, class: auth.ErrInvalidConfig},
+		{name: "cache local", construct: func() error { _, err := cache.NewLocal(nil); return err }},
+		{name: "cache distributed", construct: func() error { _, err := cache.NewDistributed(nil); return err }},
+		{name: "metrics", construct: func() error { _, err := metrics.New(nil); return err }, class: metrics.ErrInvalidConfig},
+		{name: "mq", construct: func() error { _, err := mq.New(nil); return err }, class: mq.ErrInvalidConfig},
+		{name: "ratelimit", construct: func() error { _, err := ratelimit.New(nil); return err }, class: ratelimit.ErrConfigNil},
+		{name: "trace", construct: func() error { _, err := genesistrace.Init(nil); return err }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.construct()
+			if err == nil {
+				t.Fatal("constructor accepted a nil configuration")
+			}
+			if tt.class != nil && !errors.Is(err, tt.class) {
+				t.Fatalf("error = %v, want errors.Is(_, %v)", err, tt.class)
+			}
+		})
+	}
+}
+
+func TestRC1ConfigurationMappingPreservesDurationUnitsAndNestedUnderscores(t *testing.T) {
+	t.Setenv("RC1_CONTRACT_DATABASE_MAX_OPEN_CONNS", "42")
+	t.Setenv("RC1_CONTRACT_CACHE_DEFAULT_TTL", "750ms")
+
+	loader, err := config.New(&config.Config{Paths: []string{t.TempDir()}, EnvPrefix: "RC1_CONTRACT"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if closeErr := loader.Close(); closeErr != nil {
+			t.Errorf("Close() error = %v", closeErr)
+		}
+	})
+	if err := loader.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var got struct {
+		Database struct {
+			MaxOpenConns int `mapstructure:"max_open_conns"`
+		} `mapstructure:"database"`
+		Cache struct {
+			DefaultTTL time.Duration `mapstructure:"default_ttl"`
+		} `mapstructure:"cache"`
+	}
+	if err := loader.Unmarshal(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Database.MaxOpenConns != 42 {
+		t.Fatalf("max_open_conns = %d, want 42", got.Database.MaxOpenConns)
+	}
+	if got.Cache.DefaultTTL != 750*time.Millisecond {
+		t.Fatalf("default_ttl = %v, want 750ms", got.Cache.DefaultTTL)
+	}
+}
+
+func TestRC1BorrowerCloseDoesNotCloseCallerOwnedConnector(t *testing.T) {
+	conn, err := connector.NewSQLite(&connector.SQLiteConfig{Path: "file::memory:?cache=shared"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Connect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			t.Errorf("connector Close() error = %v", closeErr)
+		}
+	})
+
+	database, err := db.New(&db.Config{Driver: "sqlite"}, db.WithSQLiteConnector(conn))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("first DB Close() error = %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("second DB Close() error = %v", err)
+	}
+	if err := conn.HealthCheck(context.Background()); err != nil {
+		t.Fatalf("borrowed connector was closed by DB: %v", err)
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.HealthCheck(context.Background()); !errors.Is(err, connector.ErrClientNil) {
+		t.Fatalf("HealthCheck() after owner Close = %v, want ErrClientNil", err)
+	}
+}
+
+func TestRC1StandaloneRateLimitCloseIsConcurrentAndTerminal(t *testing.T) {
+	limiter, err := ratelimit.New(&ratelimit.Config{
+		Driver: ratelimit.DriverStandalone,
+		Standalone: &ratelimit.StandaloneConfig{
+			CleanupInterval: time.Hour,
+			IdleTimeout:     time.Hour,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errCh := make(chan error, 8)
+	for range 8 {
+		go func() { errCh <- limiter.Close() }()
+	}
+	for range 8 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("concurrent Close() error = %v", err)
+		}
+	}
+	_, err = limiter.Allow(context.Background(), "consumer", ratelimit.Limit{Rate: 1, Burst: 1})
+	if !errors.Is(err, ratelimit.ErrLimiterClosed) {
+		t.Fatalf("Allow() after Close = %v, want ErrLimiterClosed", err)
+	}
+}
+
+func TestRC1ErrorsPreservePublicClassification(t *testing.T) {
+	if _, err := connector.NewRedis(&connector.RedisConfig{
+		Addr:        "127.0.0.1:6379",
+		DialTimeout: -time.Second,
+	}); !errors.Is(err, connector.ErrConfig) {
+		t.Fatalf("NewRedis() error = %v, want ErrConfig", err)
+	}
+	if _, err := cache.NewLocal(&cache.LocalConfig{DefaultTTL: -time.Second}); !errors.Is(err, cache.ErrInvalidTTL) {
+		t.Fatalf("NewLocal() error = %v, want ErrInvalidTTL", err)
+	}
+	if _, err := db.New(&db.Config{Driver: "unknown"}); !errors.Is(err, db.ErrInvalidConfig) {
+		t.Fatalf("db.New() error = %v, want ErrInvalidConfig", err)
+	}
+}
+
+func TestRC1TracePropagationRoundTripPreservesAssociation(t *testing.T) {
+	shutdown, err := genesistrace.InstallLocalProvider("rc1-consumer-contract")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if shutdownErr := shutdown(ctx); shutdownErr != nil {
+			t.Errorf("trace shutdown error = %v", shutdownErr)
+		}
+	})
+
+	ctx, span := otel.Tracer("contract-test").Start(context.Background(), "produce")
+	carrier := map[string]string{}
+	genesistrace.Inject(ctx, carrier)
+	span.End()
+	if carrier["traceparent"] == "" {
+		t.Fatal("Inject() did not write traceparent")
+	}
+
+	extracted := genesistrace.Extract(context.Background(), carrier)
+	remote := oteltrace.SpanContextFromContext(extracted)
+	if !remote.IsValid() || remote.TraceID() != span.SpanContext().TraceID() {
+		t.Fatalf("extracted span context = %v, want trace ID %s", remote, span.SpanContext().TraceID())
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [v0.5.0 到 v1.0.0 迁移说明](./v1-migration.md)
 - [v1 导出 API 清单](./v1-api-inventory.md)
 - [v1.0.0-rc.1 验收证据](./v1-rc1-evidence.md)
+- [v1.0.0-rc.1 契约加固与消费者风险清单](./v1-rc1-contract-hardening.md)
 
 本文档目录包含 Genesis 项目的设计文档和规范。
 

--- a/docs/v1-api-decisions.md
+++ b/docs/v1-api-decisions.md
@@ -1,6 +1,6 @@
 # Genesis v1 API and lifecycle decisions
 
-This document freezes the cross-package rules used by the `v1.0.0-rc.1` candidate. The exhaustive symbol surface is in [v1-api-inventory.md](./v1-api-inventory.md).
+This document freezes the cross-package rules published as `v1.0.0-rc.1`. The exhaustive symbol surface is in [v1-api-inventory.md](./v1-api-inventory.md).
 
 ## Constructor contract
 

--- a/docs/v1-migration.md
+++ b/docs/v1-migration.md
@@ -2,6 +2,12 @@
 
 Genesis v1 tightens failure and lifecycle contracts. Most changes are source compatible, but the items below require caller review.
 
+The currently published preview of this contract is `v1.0.0-rc.1` at
+`ec5ad2c31fb4adce2bd42529e3d7fbfe92b23aa7`. The RC is immutable: later test
+or documentation commits do not alter that module artifact. Production fixes
+require a separately approved and published RC, which consumers must select
+explicitly.
+
 ## Required source changes
 
 ### UUID errors

--- a/docs/v1-rc1-contract-hardening.md
+++ b/docs/v1-rc1-contract-hardening.md
@@ -1,0 +1,98 @@
+# v1.0.0-rc.1 contract hardening
+
+This record maps the published `v1.0.0-rc.1` contract to its active
+Resonance consumer and to the tests that protect the observable behavior. It
+does not change the API inventory or define new behavior.
+
+## Immutable baseline
+
+- Module: `github.com/ceyewan/genesis@v1.0.0-rc.1`
+- Tag commit: `ec5ad2c31fb4adce2bd42529e3d7fbfe92b23aa7`
+- Module sum: `h1:X3VK5VpPxIrgyzQsPPPSHQHaiNvMhhT/wcGCWkuFS8U=`
+- `go.mod` sum: `h1:VUPsG33Toz8lKJk2tEkgeWd7SFMIDjYtwvzYOuQmRU4=`
+- Hardening branch baseline: the same tag commit; `main` had no commits ahead
+  of the release when the branch was created.
+
+The tag, release artifact, module files, dependency versions, and
+[API inventory](./v1-api-inventory.md) remain unchanged.
+
+## Consumer-driven risk inventory
+
+A read-only scan of Resonance Go sources found the following Genesis imports.
+Counts are import occurrences, including tests, and are a prioritization aid
+rather than a coverage target.
+
+| Package     | Imports | Consumer-sensitive surface                                              | Result                                                                     |
+| ----------- | ------: | ----------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `clog`      |      81 | construction, trace-context fields, derived loggers, root close         | Existing coverage; documentation clarified                                 |
+| `mq`        |      26 | JetStream publish/subscribe, manual ack, headers, queue groups, drain   | Existing container/race coverage                                           |
+| `auth`      |      17 | constructor errors, JWT access-token validation, logger injection       | Existing coverage; external nil-config test added                          |
+| `db`        |      16 | PostgreSQL injection, transaction, borrower `Close`                     | External ownership test added                                              |
+| `connector` |      15 | Redis/PostgreSQL/NATS/etcd construction, `Connect`, owner `Close`       | Existing container coverage; external classification/ownership tests added |
+| `idgen`     |      14 | allocator, sequencer, generator, explicit duration units                | Existing Redis/etcd and exhaustion coverage                                |
+| `registry`  |      12 | etcd injection, register/watch, caller-owned gRPC connections, shutdown | Existing container/race coverage; documentation clarified                  |
+| `config`    |       8 | environment-only load, nested underscore keys, repeated close           | External environment/duration test added                                   |
+| `metrics`   |       7 | provider construction, buckets, process-global shutdown                 | Existing lifecycle coverage; external nil-config test added                |
+| `trace`     |       4 | OTLP/local provider, propagation, global shutdown                       | External propagation test added                                            |
+| `ratelimit` |       4 | standalone/distributed construction and terminal close                  | External concurrent-close test added                                       |
+| `cache`     |       1 | Redis distributed cache and borrower close                              | Existing Redis coverage; defect documented below                           |
+| `xerrors`   |       1 | wrapped error classification                                            | Existing coverage; external `errors.Is` tests added                        |
+
+Low-risk packages not used by Resonance (`breaker`, `dlock`, `idem`, and
+`testkit` as a direct import) retain their existing contract and container
+coverage. No low-value tests were added solely to increase a coverage number.
+
+## Contract sources and added evidence
+
+The external tests in `connector/rc1_consumer_contract_test.go` derive from
+[v1-api-decisions.md](./v1-api-decisions.md):
+
+- nil configurations are rejected at consumer-facing constructors;
+- nested environment keys and `time.Duration` units survive config loading;
+- a DB borrower does not close its caller-owned connector;
+- standalone rate-limit close is concurrent, idempotent, and terminal;
+- exported error sentinels remain discoverable through `errors.Is`;
+- trace carrier injection and extraction preserve trace association.
+
+The tests use only exported APIs and run in a separate package. Removing any
+of these observable behaviors makes the corresponding test fail.
+
+## Testcontainers and CI audit
+
+The ordinary and race jobs both run `go test -count=1 ./...` without skip
+flags. `testkit.RequireDocker` fails clearly when Docker is unavailable rather
+than reporting a false pass. Redis, PostgreSQL, MySQL, NATS, etcd, and Kafka
+helpers use dynamically mapped ports and `t.Cleanup` termination. PostgreSQL
+uses its module readiness strategies; MySQL has a two-minute ready-log bound;
+NATS waits for its ready log and retries client connection for at most 15
+seconds. Test keys, topics, streams, databases, and SQLite DSNs are isolated by
+the existing helpers and tests.
+
+No CI change was needed: the workflow already has separate ordinary and race
+container jobs, bounded job timeouts, and unchanged release-gate semantics.
+
+## Defect classification
+
+### RC1-BACKLOG-001: cache nil-config errors are not classifiable
+
+- Package: `cache`
+- Current behavior: `NewLocal(nil)` and `NewDistributed(nil)` return non-nil
+  errors, but the package exposes no configuration sentinel that matches those
+  errors through `errors.Is`.
+- Contract basis: the constructor table in `v1-api-decisions.md` says rejected
+  nil configurations produce a classifiable configuration error.
+- Resonance impact: not blocking. Resonance supplies a non-nil
+  `DistributedConfig` and does not depend on nil-config classification.
+- Priority: address only through an independently approved `v1.0.0-rc.2`
+  production-fix decision. This hardening work does not modify production code
+  and does not add a failing test to protected `main`.
+
+No stage-two-blocking Genesis production defect was found.
+
+## RC maintenance policy
+
+Tests, examples, and documentation merged after `v1.0.0-rc.1` do not change
+the immutable module zip and do not create a new version. A production fix,
+public API change, dependency update, or observable semantic change requires a
+separate RC decision and the complete release gate; consumers must then opt in
+to that explicitly published version. Never move or overwrite the `rc.1` tag.

--- a/docs/v1-rc1-evidence.md
+++ b/docs/v1-rc1-evidence.md
@@ -1,6 +1,9 @@
 # Genesis v1.0.0-rc.1 verification evidence
 
-This record describes the local and GitHub-hosted candidate verification performed on 2026-08-09. PR [#58](https://github.com/ceyewan/genesis/pull/58) was merged through the protected branch into `main`; its merge commit was `c80babaf35f71d656b85e28b8ae02a54e06ce7ce`. No tag, GitHub Release, or deployment has been created.
+This record describes the local and GitHub-hosted verification that culminated
+in the published `v1.0.0-rc.1` prerelease on 2026-08-09. The final protected
+merge was PR [#61](https://github.com/ceyewan/genesis/pull/61), and the annotated
+tag resolves to `ec5ad2c31fb4adce2bd42529e3d7fbfe92b23aa7`.
 
 ## Environment
 
@@ -8,6 +11,7 @@ This record describes the local and GitHub-hosted candidate verification perform
 - Docker client/server: `29.4.0` / `29.4.0`
 - Original remediation baseline: `48acd69eea91764bc8452ea3f55dfe7a2a027607`
 - Final pre-RC audit baseline: `c80babaf35f71d656b85e28b8ae02a54e06ce7ce`
+- Published RC baseline: `ec5ad2c31fb4adce2bd42529e3d7fbfe92b23aa7`
 - Scope: all 18 externally importable packages, plus examples and internal API-inventory tooling
 
 ## Full local gates
@@ -66,7 +70,13 @@ The full ordinary and race suites include regression coverage for the audit find
 - The first post-remediation `main` run [31290566522](https://github.com/ceyewan/genesis/actions/runs/31290566522) passed ordinary Testcontainers and all non-race gates but caught a transient NATS `EOF` in `TestJetStreamPublishSubscribeIntegration`; the Release gate did not run and publication stopped. Its uploaded race JSON is the evidence for the additional NATS ready-log wait and bounded connection retry in this record.
 - `main` branch protection requires those four checks on an up-to-date branch, applies to administrators, requires pull requests and resolved conversations, and disallows force pushes and deletion.
 - Controlled negative PR [#59](https://github.com/ceyewan/genesis/pull/59) introduced generated API-inventory drift. Hosted run [31288303160](https://github.com/ceyewan/genesis/actions/runs/31288303160) failed specifically at `Check exported API inventory`, and GitHub reported the PR merge state as `BLOCKED`. The PR was then closed and its remote branch deleted.
-- Independent review nevertheless withheld tag approval after reproducing the negative sequencer-step bug and the local concurrent container flake described above. The commit containing this remediation and evidence must receive a complete hosted PR run, protected merge, `main` push run, and exact-SHA pre-tag dispatch before it replaces `c80baba` as the approved candidate.
+- The final remediation passed PR #61, protected merge, exact-main, pre-tag,
+  and tag verification. The final `main` run was
+  [31290988629](https://github.com/ceyewan/genesis/actions/runs/31290988629),
+  the exact-SHA pre-tag run was
+  [31291156982](https://github.com/ceyewan/genesis/actions/runs/31291156982),
+  and the annotated-tag run was
+  [31291334025](https://github.com/ceyewan/genesis/actions/runs/31291334025).
 
 ## Accepted v1 boundaries
 
@@ -77,4 +87,10 @@ The full ordinary and race suites include regression coverage for the audit find
 - Dlock exposes ownership loss but does not issue fencing tokens; irreversible downstream writes still require CAS/version fencing.
 - Trace supports system TLS and static OTLP headers, but custom certificate-pool construction remains application/deployment configuration outside Genesis v1.
 
-No unresolved local P0/P1 API, correctness, migration, test-stability, or repository-workflow defect identified by the stage audits remains after this remediation. Required-check enforcement and both positive and negative hosted behavior are proven. Stage one is reopened until this remediation passes the complete protected PR/main/pre-tag sequence and the external stage goal records the resulting exact SHA. Tag and release creation remain separate, explicit actions.
+No unresolved local P0/P1 API, correctness, migration, test-stability, or
+repository-workflow defect identified by the release audit remained at
+publication. Required-check enforcement and both positive and negative hosted
+behavior were proven. Stage one and CI-G1 are complete; the tag and GitHub
+prerelease are published. Post-release maintenance evidence is recorded in
+[v1-rc1-contract-hardening.md](./v1-rc1-contract-hardening.md) and does not move
+or replace the published tag.


### PR DESCRIPTION
## Summary

- add external consumer-contract tests for constructor validation, error classification, environment/duration mapping, borrowed connector ownership, concurrent terminal close, and trace propagation
- document the Resonance-driven risk inventory and Testcontainers/CI stability audit
- correct stale rc.1 release evidence and clarify immutable RC maintenance policy

## Why

Genesis v1.0.0-rc.1 is already published and immutable. This change strengthens black-box evidence for behavior used by Resonance without changing production code, public APIs, module dependencies, runtime semantics, or the published tag.

The audit found one non-blocking production-contract discrepancy: cache nil-config errors are not classifiable through an exported sentinel. It is recorded as RC1-BACKLOG-001 and intentionally not fixed in this PR.

## Impact

- no production Go files changed
- go.mod, go.sum, and docs/v1-api-inventory.md remain byte-for-byte unchanged from v1.0.0-rc.1
- no tag or release changes
- Resonance remains pinned to v1.0.0-rc.1

## Validation

- go test -count=1 ./... (real Redis, PostgreSQL, MySQL, NATS, etcd, Kafka Testcontainers)
- go test -race -count=1 ./... (same real container coverage)
- golangci-lint v1.64.8 and exported-comments
- make modernize-check
- make buf-lint
- make examples-check
- make example-all
- make api-inventory-check
- make godoc-artifacts (18 artifacts)
- git diff --check
- immutable-file and production-Go scope audits