### PR TITLE
chore(tooling): align golangci-lint v2.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 env:
   GO_VERSION: "1.26.1"
-  GOLANGCI_LINT_VERSION: "v1.64.8"
+  GOLANGCI_LINT_VERSION: "v2.12.2"
   BUF_VERSION: "v1.66.1"
   ACTIONLINT_VERSION: "v1.7.7"
 
@@ -97,7 +97,7 @@ jobs:
           cache: true
       - name: Install pinned tools
         run: |
-          go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+          go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
           go install "github.com/bufbuild/buf/cmd/buf@${BUF_VERSION}"
           go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
       - name: Validate workflow syntax

--- a/.golangci-doc.yml
+++ b/.golangci-doc.yml
@@ -1,12 +1,24 @@
+version: "2"
+
 run:
   timeout: 5m
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - revive
-
-linters-settings:
-  revive:
-    rules:
-      - name: exported
+  settings:
+    revive:
+      rules:
+        - name: exported
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - (^|/)examples/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,38 +1,55 @@
+version: "2"
+
 run:
   timeout: 5m
   modules-download-mode: readonly
 
 linters:
-  disable-all: true
+  default: none
   enable:
-    - errcheck      # 检查未处理的错误
-    - govet         # Go 官方静态分析工具
-    - ineffassign   # 检查无效赋值
-    - staticcheck   # 强大的静态分析工具（含 gosimple、unused 等）
-    - typecheck     # 类型检查
-    - gofumpt       # 检查代码格式（比 gofmt 更严格）
-    - goimports     # 检查 import 格式
-    - misspell      # 检查拼写错误
-    - unconvert     # 检查不必要的类型转换
-    - unparam       # 检查未使用的函数参数
-    - nilerr        # 检查 err != nil 时返回 nil 的错误逻辑
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - unconvert
+    - unparam
+    - nilerr
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - docs
+      - deploy
+      - third_party$
+      - builtin$
+      - (^|/)examples/
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - unparam
 
-linters-settings:
-  gofumpt:
-    extra-rules: true
-  goimports:
-    local-prefixes: github.com/ceyewan/genesis
-  staticcheck:
-    checks:
-      - all
-      - "-SA1019" # 暂时允许使用 deprecated API
-
-issues:
-  exclude-dirs:
-    - docs
-    - deploy
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck   # 测试代码中允许忽略错误返回值
-        - unparam    # 测试辅助函数参数可能看起来未使用
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/ceyewan/genesis
+  exclusions:
+    generated: lax
+    paths:
+      - docs
+      - deploy
+      - third_party$
+      - builtin$
+      - (^|/)examples/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: help up down test test-race lint modernize modernize-check clean logs status examples examples-check buf-lint api-inventory api-inventory-check exported-comments godoc-artifacts
+.PHONY: help up down test test-race lint lint-tool-check modernize modernize-check clean logs status examples examples-check buf-lint api-inventory api-inventory-check exported-comments godoc-artifacts
 
 DEV_COMPOSE_FILE := deploy/dev/docker-compose.yml
 BUF_DIR := examples/proto
+GOLANGCI_LINT_VERSION ?= 2.12.2
+GOLANGCI_LINT_VERSION_NORMALIZED := $(patsubst v%,%,$(GOLANGCI_LINT_VERSION))
 
 help:
 	@echo "Genesis 开发环境"
@@ -36,7 +38,18 @@ test-race:
 	@echo "运行 race tests..."
 	@go test -race -count=1 ./...
 
-lint:
+lint-tool-check:
+	@if ! command -v golangci-lint >/dev/null 2>&1; then \
+		echo "未安装 golangci-lint，请执行: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION_NORMALIZED)"; \
+		exit 1; \
+	fi
+	@if ! golangci-lint version 2>/dev/null | grep -Fq "version $(GOLANGCI_LINT_VERSION_NORMALIZED)"; then \
+		echo "golangci-lint 版本不匹配，需要 $(GOLANGCI_LINT_VERSION_NORMALIZED)"; \
+		echo "安装命令: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION_NORMALIZED)"; \
+		exit 1; \
+	fi
+
+lint: lint-tool-check
 	@echo "运行代码检查..."
 	@golangci-lint run
 
@@ -71,7 +84,7 @@ api-inventory:
 api-inventory-check:
 	@go run ./internal/cmd/apiinventory -check docs/v1-api-inventory.md
 
-exported-comments:
+exported-comments: lint-tool-check
 	@golangci-lint run --config .golangci-doc.yml ./...
 
 godoc-artifacts:

--- a/cache/multi_test.go
+++ b/cache/multi_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//go:fix inline
-func boolPtr(b bool) *bool {
-	return new(b)
-}
-
 // mockLocalForMulti 用于测试 Multi 的本地缓存 mock
 type mockLocalForMulti struct {
 	data       map[string]any

--- a/clog/fields.go
+++ b/clog/fields.go
@@ -198,7 +198,7 @@ func getStackTrace(skip int) string {
 			break
 		}
 
-		builder.WriteString(fmt.Sprintf("%s:%d %s \n ", frame.File, frame.Line, frame.Function))
+		fmt.Fprintf(&builder, "%s:%d %s \n ", frame.File, frame.Line, frame.Function)
 		if !more {
 			break
 		}

--- a/clog/handler.go
+++ b/clog/handler.go
@@ -332,25 +332,25 @@ func (h *coloredTextHandler) colorizeOutput(output string, level slog.Level) str
 
 	// 1. 时间戳 (深灰色，低调)
 	if timeStr != "" {
-		sb.WriteString(fmt.Sprintf("%s%s%s ", ansiGray, timeStr, ansiReset))
+		fmt.Fprintf(&sb, "%s%s%s ", ansiGray, timeStr, ansiReset)
 	}
 
 	// 2. 级别 (带颜色，固定宽度对齐)
 	levelColor := h.getLevelColor(level)
 	paddedLevel := fmt.Sprintf("%-5s", levelStr)
-	sb.WriteString(fmt.Sprintf("%s%s%s%s ", ansiBold, levelColor, paddedLevel, ansiReset))
+	fmt.Fprintf(&sb, "%s%s%s%s ", ansiBold, levelColor, paddedLevel, ansiReset)
 
 	// 3. 分隔符 (竖线，增加层次感)
-	sb.WriteString(fmt.Sprintf("%s|%s ", ansiGray, ansiReset))
+	fmt.Fprintf(&sb, "%s|%s ", ansiGray, ansiReset)
 
 	// 4. 调用处 (可选：放在消息前)
 	if callerStr != "" {
-		sb.WriteString(fmt.Sprintf("%s%s%s ", ansiGray, callerStr, ansiReset))
-		sb.WriteString(fmt.Sprintf("%s>%s ", ansiCyan, ansiReset)) // 一个小箭头
+		fmt.Fprintf(&sb, "%s%s%s ", ansiGray, callerStr, ansiReset)
+		fmt.Fprintf(&sb, "%s>%s ", ansiCyan, ansiReset) // 一个小箭头
 	}
 
 	// 5. 消息主体 (最重要！白色高亮)
-	sb.WriteString(fmt.Sprintf("%s%s%s ", ansiWhite, msgStr, ansiReset))
+	fmt.Fprintf(&sb, "%s%s%s ", ansiWhite, msgStr, ansiReset)
 
 	// 6. 业务属性 (放在最后，Key 青色，Value 默认色)
 	if len(attrs) > 0 {
@@ -363,9 +363,9 @@ func (h *coloredTextHandler) colorizeOutput(output string, level slog.Level) str
 			k, v := parts[0], parts[1]
 
 			// 格式: Key(青色)=Value(默认)
-			sb.WriteString(fmt.Sprintf("%s%s%s%s=%s%s",
+			fmt.Fprintf(&sb, "%s%s%s%s=%s%s",
 				ansiCyan, k, ansiReset,
-				ansiGray, ansiReset, v))
+				ansiGray, ansiReset, v)
 		}
 	}
 

--- a/config/viper.go
+++ b/config/viper.go
@@ -469,7 +469,7 @@ func (l *loader) watchLoop(watcher *fsnotify.Watcher, targets map[string]struct{
 			if _, ok := targets[filepath.Clean(event.Name)]; !ok {
 				continue
 			}
-			if !(event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) || event.Has(fsnotify.Remove) || event.Has(fsnotify.Chmod)) {
+			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Rename) && !event.Has(fsnotify.Remove) && !event.Has(fsnotify.Chmod) {
 				continue
 			}
 

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -666,7 +666,6 @@ func TestConnectorInterface(t *testing.T) {
 
 		// Verify interface compliance
 		var _ Connector = conn
-		var _ RedisConnector = conn
 
 		// Test basic interface methods
 		require.Equal(t, "default", conn.Name())
@@ -689,7 +688,6 @@ func TestConnectorInterface(t *testing.T) {
 		defer conn.Close()
 
 		var _ Connector = conn
-		var _ MySQLConnector = conn
 		var _ TypedConnector[*gorm.DB] = conn
 
 		require.Equal(t, "default", conn.Name())
@@ -705,7 +703,6 @@ func TestConnectorInterface(t *testing.T) {
 		defer conn.Close()
 
 		var _ Connector = conn
-		var _ EtcdConnector = conn
 
 		require.Equal(t, "default", conn.Name())
 		require.Nil(t, conn.GetClient()) // Not connected yet
@@ -719,7 +716,6 @@ func TestConnectorInterface(t *testing.T) {
 		require.NoError(t, err)
 
 		var _ Connector = conn
-		var _ NATSConnector = conn
 
 		require.Equal(t, "default", conn.Name())
 		require.Nil(t, conn.GetClient()) // Not connected yet
@@ -733,7 +729,6 @@ func TestConnectorInterface(t *testing.T) {
 		require.NoError(t, err)
 
 		var _ Connector = conn
-		var _ KafkaConnector = conn
 
 		require.Equal(t, "default", conn.Name())
 		require.Nil(t, conn.GetClient()) // Not connected yet
@@ -748,7 +743,6 @@ func TestConnectorInterface(t *testing.T) {
 		defer conn.Close()
 
 		var _ Connector = conn
-		var _ SQLiteConnector = conn
 		var _ TypedConnector[*gorm.DB] = conn
 
 		require.Equal(t, "default", conn.Name())

--- a/idem/refactor_test.go
+++ b/idem/refactor_test.go
@@ -70,7 +70,7 @@ func TestExecute_ReturnTypeStable(t *testing.T) {
 func TestExecute_RecoversFromCorruptedCachedResult(t *testing.T) {
 	t.Parallel()
 
-	store := newMemoryStore("test:idem:corrupt:").(Store)
+	store := newMemoryStore("test:idem:corrupt:")
 	idemComp := newIdempotency(&Config{
 		Driver:     DriverMemory,
 		Prefix:     "test:idem:corrupt:",


### PR DESCRIPTION
## Summary

- align Genesis with Resonance on `golangci-lint v2.12.2`
- migrate the primary and exported-comment lint configs to the v2 schema
- pin and verify the local tool version through Make targets
- update CI to install the v2 module path
- apply the small mechanical cleanups surfaced by the v2 analyzers

## Why

Genesis was still pinned to `v1.64.8` while Resonance and the shared local development environment use `v2.12.2`. This made local lint commands fail on Genesis even though the same binary was correct for Resonance.

After this PR, both repositories use the same golangci-lint version:

- Genesis: `2.12.2`
- Resonance: `2.12.2`
- local development binary: `2.12.2`

The Makefile now fails early with the exact installation command when the binary is missing or the version does not match.

## Migration notes

The v2 analyzers surfaced a small number of mechanical issues. The cleanup replaces redundant `WriteString(fmt.Sprintf(...))` calls, simplifies one equivalent boolean condition, removes redundant interface assertions and a redundant type assertion, and removes one unused test helper. No public API or intended runtime semantics change.

The existing v1 exclusion behavior is preserved during schema migration so this tooling PR does not absorb unrelated historical documentation/example cleanup.

This PR is independent of #63 and has no overlapping files.

## Validation

- `make lint` with golangci-lint `2.12.2`: 0 issues
- `make exported-comments`: 0 issues
- `golangci-lint config verify` for both configs
- `go test -count=1 ./...` with real Testcontainers dependencies
- `make modernize-check`
- `make examples-check`
- `make api-inventory-check`
- `actionlint`
- `git diff --check`