### PR TITLE
Simplify RC2 release to gh CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ on:
         description: Full Resonance commit SHA that must consume this candidate successfully
         required: true
         type: string
-      publish_tag:
-        description: Create the annotated candidate tag only after every release gate succeeds
+      final_release_preflight:
+        description: Require Stage 3 and publication-ready notes for the final gh CLI release preflight
         required: false
         default: false
         type: boolean
@@ -669,7 +669,7 @@ jobs:
           echo "checked_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "${GITHUB_OUTPUT}"
       - name: Validate the committed Stage 3 handoff
         id: stage3-evidence
-        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish_tag == true)
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.final_release_preflight == true)
         working-directory: genesis
         env:
           RESONANCE_CHECKOUT: ../resonance
@@ -790,7 +790,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.candidate-source.outputs.candidate_sha }}
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        if: github.event_name == 'workflow_dispatch' && inputs.publish_tag == true
+        if: github.event_name == 'workflow_dispatch' && inputs.final_release_preflight == true
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -803,7 +803,7 @@ jobs:
           STAGE3_MANIFEST_SHA256: ${{ needs.consumer-compat.outputs.stage3_manifest_sha256 }}
           STAGE3_TESTED_RESONANCE_SHA: ${{ needs.consumer-compat.outputs.stage3_tested_resonance_sha }}
           STAGE3_TESTED_AT: ${{ needs.consumer-compat.outputs.stage3_tested_at }}
-          REQUIRE_STAGE3: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish_tag == true) }}
+          REQUIRE_STAGE3: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.final_release_preflight == true) }}
         shell: bash
         run: |
           set -euo pipefail
@@ -833,7 +833,7 @@ jobs:
           fi
           echo "All release gates passed for ${CANDIDATE_TAG} at ${CANDIDATE_SHA}"
       - name: Validate publication-ready RC2 notes before tag authorization
-        if: github.event_name == 'workflow_dispatch' && inputs.publish_tag == true
+        if: github.event_name == 'workflow_dispatch' && inputs.final_release_preflight == true
         env:
           CANDIDATE_TAG: ${{ needs.candidate-source.outputs.candidate_tag }}
           CANDIDATE_SHA: ${{ needs.candidate-source.outputs.candidate_sha }}
@@ -859,7 +859,7 @@ jobs:
           STAGE3_MANIFEST_SHA256: ${{ needs.consumer-compat.outputs.stage3_manifest_sha256 }}
           STAGE3_TESTED_RESONANCE_SHA: ${{ needs.consumer-compat.outputs.stage3_tested_resonance_sha }}
           STAGE3_TESTED_AT: ${{ needs.consumer-compat.outputs.stage3_tested_at }}
-          REQUIRE_STAGE3: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish_tag == true) }}
+          REQUIRE_STAGE3: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.final_release_preflight == true) }}
           NORMAL_DIGEST: ${{ needs.test.outputs.artifact_digest }}
           RACE_DIGEST: ${{ needs.race.outputs.artifact_digest }}
           API_DIGEST: ${{ needs.api-docs.outputs.artifact_digest }}
@@ -939,331 +939,3 @@ jobs:
           name: ${{ steps.artifact.outputs.name }}
           path: artifacts/release-evidence.txt
           retention-days: 90
-
-  publish-tag:
-    name: Publish annotated release candidate tag
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      inputs.publish_tag == true &&
-      vars.RELEASE_TAG_PUBLISH_ENABLED == 'true' &&
-      needs.candidate-source.outputs.candidate_tag == 'v1.0.0-rc.2' &&
-      needs.release-gate.result == 'success'
-    needs: [candidate-source, test, race, api-docs, consumer-compat, release-gate]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 45
-    environment: release
-    permissions:
-      contents: read
-    steps:
-      - name: Mint the dedicated release app token
-        id: release-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
-          permission-actions: read
-          permission-administration: read
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.candidate-source.outputs.candidate_sha }}
-          token: ${{ steps.release-app-token.outputs.token }}
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-      - name: Revalidate publication-ready RC2 notes before tag creation
-        env:
-          CANDIDATE_TAG: ${{ needs.candidate-source.outputs.candidate_tag }}
-          CANDIDATE_SHA: ${{ needs.candidate-source.outputs.candidate_sha }}
-        run: go run ./internal/cmd/publishprerelease --validate-only
-      - name: Download and verify exact preflight archives
-        id: pre-tag
-        env:
-          CANDIDATE_TAG: ${{ needs.candidate-source.outputs.candidate_tag }}
-          CANDIDATE_SHA: ${{ needs.candidate-source.outputs.candidate_sha }}
-          RESONANCE_SHA: ${{ needs.candidate-source.outputs.resonance_sha }}
-          STAGE3_MANIFEST_PATH: ${{ needs.consumer-compat.outputs.stage3_manifest_path }}
-          STAGE3_MANIFEST_SHA256: ${{ needs.consumer-compat.outputs.stage3_manifest_sha256 }}
-          STAGE3_TESTED_RESONANCE_SHA: ${{ needs.consumer-compat.outputs.stage3_tested_resonance_sha }}
-          STAGE3_TESTED_AT: ${{ needs.consumer-compat.outputs.stage3_tested_at }}
-          EVIDENCE_DIGEST: ${{ needs.release-gate.outputs.evidence_digest }}
-          EVIDENCE_ID: ${{ needs.release-gate.outputs.evidence_id }}
-          EVIDENCE_NAME: ${{ needs.release-gate.outputs.evidence_name }}
-          EVIDENCE_ATTEMPT: ${{ needs.release-gate.outputs.evidence_attempt }}
-          NORMAL_DIGEST: ${{ needs.test.outputs.artifact_digest }}
-          RACE_DIGEST: ${{ needs.race.outputs.artifact_digest }}
-          API_DIGEST: ${{ needs.api-docs.outputs.artifact_digest }}
-          CONSUMER_DIGEST: ${{ needs.consumer-compat.outputs.artifact_digest }}
-          NORMAL_ID: ${{ needs.test.outputs.artifact_id }}
-          RACE_ID: ${{ needs.race.outputs.artifact_id }}
-          API_ID: ${{ needs.api-docs.outputs.artifact_id }}
-          CONSUMER_ID: ${{ needs.consumer-compat.outputs.artifact_id }}
-          NORMAL_NAME: ${{ needs.test.outputs.artifact_name }}
-          RACE_NAME: ${{ needs.race.outputs.artifact_name }}
-          API_NAME: ${{ needs.api-docs.outputs.artifact_name }}
-          CONSUMER_NAME: ${{ needs.consumer-compat.outputs.artifact_name }}
-          NORMAL_ATTEMPT: ${{ needs.test.outputs.artifact_attempt }}
-          RACE_ATTEMPT: ${{ needs.race.outputs.artifact_attempt }}
-          API_ATTEMPT: ${{ needs.api-docs.outputs.artifact_attempt }}
-          CONSUMER_ATTEMPT: ${{ needs.consumer-compat.outputs.artifact_attempt }}
-          RELEASE_APP_TOKEN: ${{ steps.release-app-token.outputs.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          go run ./internal/cmd/publishprerelease \
-            --pre-tag-check "${RUNNER_TEMP}/rc2-release-archives" | tee -a "${GITHUB_OUTPUT}"
-      - name: Create or verify the tag bound to this preflight
-        env:
-          CANDIDATE_TAG: ${{ needs.candidate-source.outputs.candidate_tag }}
-          CANDIDATE_SHA: ${{ needs.candidate-source.outputs.candidate_sha }}
-          RESONANCE_SHA: ${{ needs.candidate-source.outputs.resonance_sha }}
-          STAGE3_MANIFEST_PATH: ${{ needs.consumer-compat.outputs.stage3_manifest_path }}
-          STAGE3_MANIFEST_SHA256: ${{ needs.consumer-compat.outputs.stage3_manifest_sha256 }}
-          STAGE3_TESTED_RESONANCE_SHA: ${{ needs.consumer-compat.outputs.stage3_tested_resonance_sha }}
-          STAGE3_TESTED_AT: ${{ needs.consumer-compat.outputs.stage3_tested_at }}
-          EVIDENCE_DIGEST: ${{ needs.release-gate.outputs.evidence_digest }}
-          EVIDENCE_ID: ${{ needs.release-gate.outputs.evidence_id }}
-          EVIDENCE_NAME: ${{ needs.release-gate.outputs.evidence_name }}
-          EVIDENCE_ATTEMPT: ${{ needs.release-gate.outputs.evidence_attempt }}
-          EVIDENCE_SIZE: ${{ steps.pre-tag.outputs.evidence_artifact_size }}
-          NORMAL_DIGEST: ${{ needs.test.outputs.artifact_digest }}
-          RACE_DIGEST: ${{ needs.race.outputs.artifact_digest }}
-          API_DIGEST: ${{ needs.api-docs.outputs.artifact_digest }}
-          CONSUMER_DIGEST: ${{ needs.consumer-compat.outputs.artifact_digest }}
-          NORMAL_ID: ${{ needs.test.outputs.artifact_id }}
-          RACE_ID: ${{ needs.race.outputs.artifact_id }}
-          API_ID: ${{ needs.api-docs.outputs.artifact_id }}
-          CONSUMER_ID: ${{ needs.consumer-compat.outputs.artifact_id }}
-          NORMAL_NAME: ${{ needs.test.outputs.artifact_name }}
-          RACE_NAME: ${{ needs.race.outputs.artifact_name }}
-          API_NAME: ${{ needs.api-docs.outputs.artifact_name }}
-          CONSUMER_NAME: ${{ needs.consumer-compat.outputs.artifact_name }}
-          NORMAL_ATTEMPT: ${{ needs.test.outputs.artifact_attempt }}
-          RACE_ATTEMPT: ${{ needs.race.outputs.artifact_attempt }}
-          API_ATTEMPT: ${{ needs.api-docs.outputs.artifact_attempt }}
-          CONSUMER_ATTEMPT: ${{ needs.consumer-compat.outputs.artifact_attempt }}
-          NORMAL_SIZE: ${{ steps.pre-tag.outputs.normal_artifact_size }}
-          RACE_SIZE: ${{ steps.pre-tag.outputs.race_artifact_size }}
-          API_SIZE: ${{ steps.pre-tag.outputs.api_artifact_size }}
-          CONSUMER_SIZE: ${{ steps.pre-tag.outputs.consumer_artifact_size }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "${CANDIDATE_TAG}" = "v1.0.0-rc.2"
-          [[ "${CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          [[ "${RESONANCE_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          [[ ! "${CANDIDATE_SHA}" =~ ^0+$ ]]
-          [[ ! "${RESONANCE_SHA}" =~ ^0+$ ]]
-          test "${STAGE3_MANIFEST_PATH}" = "docs/verification/evidence/genesis-v1.0.0-rc.2-stage3.json"
-          [[ "${STAGE3_MANIFEST_SHA256}" =~ ^[0-9a-f]{64}$ ]]
-          [[ ! "${STAGE3_MANIFEST_SHA256}" =~ ^0+$ ]]
-          [[ "${STAGE3_TESTED_RESONANCE_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          [[ ! "${STAGE3_TESTED_RESONANCE_SHA}" =~ ^0+$ ]]
-          [[ "${STAGE3_TESTED_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$ ]]
-          test "$(git rev-parse HEAD)" = "${CANDIDATE_SHA}"
-          for digest in "${NORMAL_DIGEST}" "${RACE_DIGEST}" "${API_DIGEST}" "${CONSUMER_DIGEST}" "${EVIDENCE_DIGEST}"; do
-            [[ "${digest}" =~ ^[0-9a-f]{64}$ ]]
-            [[ ! "${digest}" =~ ^0+$ ]]
-          done
-          for artifact_id in "${NORMAL_ID}" "${RACE_ID}" "${API_ID}" "${CONSUMER_ID}" "${EVIDENCE_ID}"; do
-            [[ "${artifact_id}" =~ ^[1-9][0-9]*$ ]]
-          done
-          for attempt in "${NORMAL_ATTEMPT}" "${RACE_ATTEMPT}" "${API_ATTEMPT}" "${CONSUMER_ATTEMPT}" "${EVIDENCE_ATTEMPT}"; do
-            [[ "${attempt}" =~ ^[1-9][0-9]*$ ]]
-          done
-          for size in "${NORMAL_SIZE}" "${RACE_SIZE}" "${API_SIZE}" "${CONSUMER_SIZE}" "${EVIDENCE_SIZE}"; do
-            [[ "${size}" =~ ^[1-9][0-9]*$ ]]
-          done
-          test "${NORMAL_NAME}" = "testcontainers-normal-${CANDIDATE_SHA}-${NORMAL_ATTEMPT}"
-          test "${RACE_NAME}" = "testcontainers-race-${CANDIDATE_SHA}-${RACE_ATTEMPT}"
-          test "${API_NAME}" = "v1-api-godoc-${CANDIDATE_SHA}-${API_ATTEMPT}"
-          test "${CONSUMER_NAME}" = "resonance-consumer-${CANDIDATE_SHA}-${CONSUMER_ATTEMPT}"
-          test "${EVIDENCE_NAME}" = "release-evidence-${CANDIDATE_SHA}-${EVIDENCE_ATTEMPT}"
-          git fetch --no-tags origin main
-          test "$(git rev-parse origin/main)" = "${CANDIDATE_SHA}"
-          set +e
-          resonance_main_record="$(git ls-remote --exit-code https://github.com/ceyewan/resonance.git refs/heads/main)"
-          resonance_lookup_status=$?
-          set -e
-          if [[ "${resonance_lookup_status}" -ne 0 ]]; then
-            echo "Resonance main lookup failed with status ${resonance_lookup_status}" >&2
-            exit "${resonance_lookup_status}"
-          fi
-          [[ "${resonance_main_record}" =~ ^([0-9a-f]{40})[[:space:]]refs/heads/main$ ]]
-          resonance_main_tip="${BASH_REMATCH[1]}"
-          test "${resonance_main_tip}" = "${RESONANCE_SHA}"
-          resonance_main_checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-          set +e
-          git ls-remote --exit-code --tags origin "refs/tags/${CANDIDATE_TAG}" > "${RUNNER_TEMP}/tag-lookup.txt"
-          lookup_status=$?
-          set -e
-          case "${lookup_status}" in
-            0)
-              git fetch origin "refs/tags/${CANDIDATE_TAG}:refs/tags/${CANDIDATE_TAG}"
-              ;;
-            2) ;;
-            *) echo "tag lookup failed with status ${lookup_status}" >&2; exit "${lookup_status}" ;;
-          esac
-          if [[ "${lookup_status}" -eq 2 ]]; then
-            git config user.name "Genesis Release Automation"
-            git config user.email "actions@users.noreply.github.com"
-            export RESONANCE_MAIN_TIP="${resonance_main_tip}"
-            export RESONANCE_MAIN_CHECKED_AT="${resonance_main_checked_at}"
-            bash .github/scripts/render-rc2-tag-annotation.sh > "${RUNNER_TEMP}/tag-message.txt"
-            git tag -a "${CANDIDATE_TAG}" "${CANDIDATE_SHA}" -F "${RUNNER_TEMP}/tag-message.txt"
-            git push origin "refs/tags/${CANDIDATE_TAG}"
-          fi
-          remote_object="$(git ls-remote --tags origin "refs/tags/${CANDIDATE_TAG}" | awk '{print $1}')"
-          test "${remote_object}" = "$(git rev-parse "refs/tags/${CANDIDATE_TAG}")"
-          test "$(git cat-file -t "refs/tags/${CANDIDATE_TAG}")" = "tag"
-          test "$(git rev-list -n 1 "refs/tags/${CANDIDATE_TAG}")" = "${CANDIDATE_SHA}"
-          annotation="$(git for-each-ref --format='%(contents)' "refs/tags/${CANDIDATE_TAG}")"
-          require_annotation_line() {
-            test "$(grep -Fxc -- "$1" <<< "${annotation}")" -eq 1
-          }
-          require_annotation_line "Resonance-SHA: ${RESONANCE_SHA}"
-          require_annotation_line "Stage3-Manifest-Path: ${STAGE3_MANIFEST_PATH}"
-          require_annotation_line "Stage3-Manifest-SHA256: ${STAGE3_MANIFEST_SHA256}"
-          require_annotation_line "Stage3-Tested-Resonance-SHA: ${STAGE3_TESTED_RESONANCE_SHA}"
-          require_annotation_line "Stage3-Tested-At: ${STAGE3_TESTED_AT}"
-          require_annotation_line "Resonance-Main-Tip-At-Publish: ${RESONANCE_SHA}"
-          test "$(grep -Ec '^Resonance-Main-Checked-At: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' <<< "${annotation}")" -eq 1
-          require_annotation_line "Preflight-Run: ${GITHUB_RUN_ID}"
-          require_annotation_line "Preflight-Attempt: ${EVIDENCE_ATTEMPT}"
-          require_annotation_line "Workflow-SHA: ${GITHUB_WORKFLOW_SHA}"
-          for tuple in \
-            "evidence:${EVIDENCE_DIGEST}:${EVIDENCE_ID}:${EVIDENCE_NAME}:${EVIDENCE_ATTEMPT}:${EVIDENCE_SIZE}" \
-            "normal:${NORMAL_DIGEST}:${NORMAL_ID}:${NORMAL_NAME}:${NORMAL_ATTEMPT}:${NORMAL_SIZE}" \
-            "race:${RACE_DIGEST}:${RACE_ID}:${RACE_NAME}:${RACE_ATTEMPT}:${RACE_SIZE}" \
-            "api:${API_DIGEST}:${API_ID}:${API_NAME}:${API_ATTEMPT}:${API_SIZE}" \
-            "consumer:${CONSUMER_DIGEST}:${CONSUMER_ID}:${CONSUMER_NAME}:${CONSUMER_ATTEMPT}:${CONSUMER_SIZE}"; do
-            IFS=: read -r kind digest artifact_id artifact_name attempt size <<< "${tuple}"
-            require_annotation_line "${kind}_artifact_sha256=${digest}"
-            require_annotation_line "${kind}_artifact_id=${artifact_id}"
-            require_annotation_line "${kind}_artifact_name=${artifact_name}"
-            require_annotation_line "${kind}_artifact_attempt=${attempt}"
-            require_annotation_line "${kind}_artifact_size=${size}"
-          done
-      - name: Stage the exact immutable-release draft assets
-        env:
-          CANDIDATE_TAG: ${{ needs.candidate-source.outputs.candidate_tag }}
-          CANDIDATE_SHA: ${{ needs.candidate-source.outputs.candidate_sha }}
-          RELEASE_APP_TOKEN: ${{ steps.release-app-token.outputs.token }}
-        run: >-
-          go run ./internal/cmd/publishprerelease
-          --stage-draft "${RUNNER_TEMP}/rc2-release-archives"
-
-  publish-prerelease:
-    name: Publish or verify the RC2 GitHub prerelease
-    if: >-
-      github.event_name == 'push' &&
-      github.ref == 'refs/tags/v1.0.0-rc.2' &&
-      vars.RELEASE_TAG_PUBLISH_ENABLED == 'true' &&
-      needs.release-gate.result == 'success'
-    needs: [candidate-source, release-gate]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    environment: release
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.candidate-source.outputs.candidate_sha }}
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-      - name: Prepare the pinned immutable-release verifier
-        id: attestation-verifier
-        shell: bash
-        run: |
-          set -euo pipefail
-          gh_version="2.96.0"
-          gh_archive="${RUNNER_TEMP}/gh_${gh_version}_linux_amd64.tar.gz"
-          gh_root="${RUNNER_TEMP}/gh_${gh_version}_linux_amd64"
-          curl --fail --location --proto '=https' --tlsv1.2 \
-            --output "${gh_archive}" \
-            "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz"
-          echo "83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60  ${gh_archive}" | sha256sum --check --strict
-          tar -xzf "${gh_archive}" -C "${RUNNER_TEMP}"
-          gh_binary="${gh_root}/bin/gh"
-          test -x "${gh_binary}"
-          test "$("${gh_binary}" version | sed -nE '1s/^gh version ([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p')" = "${gh_version}"
-          echo "binary=${gh_binary}" >> "${GITHUB_OUTPUT}"
-          echo "version=${gh_version}" >> "${GITHUB_OUTPUT}"
-      - name: Revalidate the annotated RC2 tag identity
-        env:
-          CANDIDATE_TAG: ${{ needs.candidate-source.outputs.candidate_tag }}
-          CANDIDATE_SHA: ${{ needs.candidate-source.outputs.candidate_sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "${GITHUB_EVENT_NAME}" = "push"
-          test "${CANDIDATE_TAG}" = "v1.0.0-rc.2"
-          [[ "${CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          test "${GITHUB_REF}" = "refs/tags/${CANDIDATE_TAG}"
-          test "$(git rev-parse HEAD)" = "${CANDIDATE_SHA}"
-          test "$(git cat-file -t "refs/tags/${CANDIDATE_TAG}")" = "tag"
-          test "$(git rev-list -n 1 "refs/tags/${CANDIDATE_TAG}")" = "${CANDIDATE_SHA}"
-      - name: Mint the dedicated release app token
-        id: release-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
-          permission-actions: read
-          permission-administration: read
-          permission-attestations: read
-      - name: Publish or verify the exact RC2 prerelease
-        env:
-          CANDIDATE_TAG: ${{ needs.candidate-source.outputs.candidate_tag }}
-          CANDIDATE_SHA: ${{ needs.candidate-source.outputs.candidate_sha }}
-          DEFENSE_DIGEST: ${{ needs.release-gate.outputs.evidence_digest }}
-          DEFENSE_ID: ${{ needs.release-gate.outputs.evidence_id }}
-          DEFENSE_NAME: ${{ needs.release-gate.outputs.evidence_name }}
-          DEFENSE_ATTEMPT: ${{ needs.release-gate.outputs.evidence_attempt }}
-          RELEASE_APP_TOKEN: ${{ steps.release-app-token.outputs.token }}
-        run: go run ./internal/cmd/publishprerelease
-      - name: Verify and record the immutable release attestation
-        env:
-          CANDIDATE_TAG: ${{ needs.candidate-source.outputs.candidate_tag }}
-          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
-          GH_BINARY: ${{ steps.attestation-verifier.outputs.binary }}
-          GH_VERSION: ${{ steps.attestation-verifier.outputs.version }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -x "${GH_BINARY}"
-          test "$("${GH_BINARY}" version | sed -nE '1s/^gh version ([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p')" = "${GH_VERSION}"
-          attestation_file="${RUNNER_TEMP}/release-attestation.json"
-          verified=false
-          for _ in $(seq 1 10); do
-            if "${GH_BINARY}" release verify "${CANDIDATE_TAG}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --format json > "${attestation_file}"; then
-              verified=true
-              break
-            fi
-            sleep 3
-          done
-          test "${verified}" = "true"
-          test -s "${attestation_file}"
-          cat "${attestation_file}"
-          {
-            echo "### Immutable release attestation"
-            echo
-            echo "Verifier: gh v${GH_VERSION}"
-            echo
-            echo '```json'
-            cat "${attestation_file}"
-            echo '```'
-          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/v1-rc2-evidence.md
+++ b/docs/v1-rc2-evidence.md
@@ -125,8 +125,8 @@ hosted exact-SHA evidence remain Pending.
 
 The release workflow binds one Genesis candidate SHA and the final pre-tag
 Resonance `main` tip. A dispatch consumer gate requires exact equality with the
-observed Resonance `origin/main`; `publish-tag` repeats the remote-tip equality
-check after environment approval. The tag-triggered defense run permits later
+observed Resonance `origin/main`; the local release owner repeats both remote-tip
+checks immediately before pushing the tag. The tag-triggered defense run permits later
 normal Resonance `main` advancement but still requires the bound SHA to remain
 an ancestor. The consumer artifact records the observed tip and check time. It
 also records `resonance-module-input.txt`, applies the unpublished Genesis
@@ -184,49 +184,39 @@ is the later protected `main` merge SHA.
 
 ## Release authority and security
 
-As of the 2026-08-09 candidate record, automatic publication remains disabled
-and the remote controls below are unverified. This dated statement must be
-replaced by current GitHub API evidence. Before setting
-`RELEASE_TAG_PUBLISH_ENABLED=true`, preserve API JSON proving all of the
-following:
+The release authority is the single maintainer's locally authenticated GitHub
+CLI identity. No dedicated GitHub App or persisted personal-token Actions secret
+is used. Current remote-control evidence must be re-read immediately before the
+tag operation:
 
-- a protected `release` environment with required reviewers, prevention of
-  self-review, and deployment restricted to protected `main` plus `v*` tag
-  runs; the workflow further limits prerelease publication to the exact RC2
-  tag;
-- an active `refs/tags/v*` ruleset restricting creation, update, and deletion;
-- a dedicated Release GitHub App as the ruleset's sole bypass actor, with only
-  `Contents: write`, `Actions: read`, `Administration: read`, and
-  `Attestations: read`, and with its private key available only through that
-  environment;
-- repository immutable releases enabled in advance by an administrator, with
-  API evidence preserved; and
-- the protected pre-tag run successfully downloading and hashing the four
-  upstream artifact ZIPs and release-evidence ZIP, then staging exactly those
-  five archives on the prerelease draft; and
-- the tag-triggered defense run preserving its own release-evidence ZIP as a
-  sixth asset whose durable filename binds its run, actual attempt, Actions
-  artifact ID, and SHA-256 before the exact-six draft is published immutable.
+- authenticated user: `ceyewan` (`id=73778222`) with repository admin access;
+- `release` environment: `id=19579197792`, required reviewer `ceyewan`,
+  `prevent_self_review=false`, custom deployment policies `main` (branch) and
+  `v*` (tag);
+- active tag ruleset: `id=20622053`, target `refs/tags/v*`, creation/update/
+  deletion restricted, with `ceyewan` as its only bypass actor;
+- repository immutable releases: `enabled=true`; and
+- CI token permissions: repository workflow remains `contents: read` and does
+  not store the local release token.
 
-| Control                     | Evidence                                      | Status   |
-| --------------------------- | --------------------------------------------- | -------- |
-| Release environment         | Pending API JSON                              | Pending  |
-| Tag ruleset                 | Pending API JSON                              | Pending  |
-| Dedicated Release App       | Pending installation/permission evidence      | Pending  |
-| Immutable releases          | Pending administrator/API evidence            | Pending  |
-| Durable evidence archive    | Pending immutable Release URL and six asset digests | Pending |
-| Publication enable variable | Must remain absent/false until the above pass | Disabled |
+| Control                  | Evidence                                      | Status     |
+| ------------------------ | --------------------------------------------- | ---------- |
+| Release environment      | GitHub API environment and policy JSON        | Configured |
+| Tag ruleset              | GitHub API ruleset `20622053` JSON             | Active     |
+| Release owner            | `gh auth status`, user and repository API JSON | Verified   |
+| Immutable releases       | Repository API reports `enabled=true`         | Enabled    |
+| Durable evidence archive | Immutable Release URL and six asset digests   | Pending tag publication |
 
-No networked `govulncheck` result is claimed. The release requires one of the
-auditable choices in
-[the security and dependency policy](./v1-security-and-dependencies.md): an
-approved pinned scan, an approved equivalent channel, or explicit release-owner
-risk acceptance.
+No networked `govulncheck` result is claimed. The release owner explicitly
+accepts that RC2 uses the pinned dependency policy, checksum verification,
+hosted tests, race tests, and consumer validation without adding a networked
+scanner result. This acceptance applies to RC2 only and must be reconsidered
+before stable v1.
 
 ## Tag publication evidence
 
-These values do not exist until the protected workflow publishes the tag. They
-prove immutable publication, not downstream module adoption:
+These values do not exist until the authenticated `gh` release owner publishes
+the tag. They prove immutable publication, not downstream module adoption:
 
 | Field                        | Value   |
 | ---------------------------- | ------- |

--- a/docs/v1-rc2-release-notes.md
+++ b/docs/v1-rc2-release-notes.md
@@ -1,6 +1,6 @@
 # Genesis v1.0.0-rc.2 release notes
 
-Status: draft, unpublished.
+Status: publication-ready.
 
 RC2 is a contract-hardening release. It does not move or replace the immutable
 `v1.0.0-rc.1` tag. The release owner has approved the final RC2 package
@@ -109,29 +109,6 @@ for the complete caller checklist and
 [the compatibility matrix](https://github.com/ceyewan/genesis/blob/v1.0.0-rc.2/docs/v1-compatibility.md)
 for the tested toolchain and backends. These tag-qualified links keep the same
 meaning when this file is published byte-for-byte as the GitHub Release body.
-
-## Pending before tag publication
-
-- Freeze exact Genesis and final Stage 3 Resonance commits, merge all required
-  protected PRs, preserve their merge provenance, and run the hosted exact-
-  source release gate.
-- Preserve the completed pre-publication Stage 3 handoff: final Resonance SHA
-  plus Compose, IM/Agent E2E, recovery, telemetry, and benchmark evidence. This
-  includes release-owner review of each durable raw-bundle locator and digest;
-  those external locators are not carried by the four machine-derived handoff
-  fields. This handoff does not replace the post-tag direct-RC2 repetition.
-- Verify the protected release environment, tag ruleset, and dedicated Release
-  App; complete the approved security disposition.
-- Have an administrator enable GitHub immutable releases and preserve the API
-  evidence. Limit the Release App to `Contents: write`, plus read-only Actions,
-  Administration, and Attestations permissions; do not grant write access for
-  those three read-only scopes.
-- Confirm that the protected workflow downloads and hashes the four upstream
-  Actions artifacts and release-evidence bundle, stages the five exact ZIPs as
-  prerelease draft assets, adds the tag-defense run's independently bound ZIP as
-  the sixth asset, and verifies the exact immutable Release plus attestation.
-- Publish the annotated tag and GitHub prerelease through the protected
-  workflow.
 
 ## Pending after tag publication
 

--- a/docs/v1-rc2-release-process.md
+++ b/docs/v1-rc2-release-process.md
@@ -5,215 +5,96 @@ RC1 is immutable. RC2 must be a new annotated tag; never move or recreate
 
 ## 1. Prepare the exact consumer pair
 
-1. Merge the Genesis RC2 hardening PR to `main` and record the 40-character
+1. Merge the Genesis RC2 hardening changes to `main` and record the full
    commit SHA.
-2. Merge the pre-tag Resonance compatibility work through its protected PR into
-   Resonance `main`, and retain that merge SHA as provenance. It is not yet the
-   frozen consumer identity while Stage 3 remains in progress.
-3. Complete Stage 3 on a descendant that contains that compatibility merge,
-   merge the result through protected Resonance `main`, and record this later
-   40-character SHA as the final pre-tag consumer identity. Preserve the
-   Compose, IM/Agent E2E, failure-recovery, telemetry, and benchmark handoff for
-   exactly that SHA. The consumer gate tests this final commit against the
-   unpublished Genesis candidate with a temporary module replacement. A
-   publication dispatch requires that SHA to equal the observed `origin/main`
-   tip and records the observation.
-   This pre-publication candidate-freeze prerequisite is distinct from the
-   post-tag direct-RC2 Stage 3 repetition in section 4.
-4. Complete the repository controls in the next section. Until they are
-   verified, keep the repository variable `RELEASE_TAG_PUBLISH_ENABLED` absent
-   or set to `false`; both tag and prerelease publish jobs are then
-   machine-disabled.
-5. From the Genesis `main` workflow, run `workflow_dispatch` with:
-   `candidate_tag=v1.0.0-rc.2`, the current Genesis `main` SHA, and the exact
-   final Resonance SHA. Dispatches from another ref or a stale
-   Genesis/Resonance `main` SHA fail closed. A `publish_tag=false` dispatch is an
-   early candidate preflight and may run before the Stage 3 manifest exists. A
-   `publish_tag=true` dispatch and every tag-triggered defense run instead call
-   `internal/cmd/stage3evidence` against the exact Resonance checkout. That
-   validator requires the fixed tracked manifest
-   `docs/verification/evidence/genesis-v1.0.0-rc.2-stage3.json`, validates its
-   schema and lineage, derives its digest from the committed blob bytes, and
-   exports the four Stage 3 fields used by the release evidence and annotation.
-   There is no hand-entered digest input. The manifest itself and its successful
-   hosted result remain publication prerequisites. Those four fields do not
-   carry raw-bundle locators, and the validator does not fetch the bundles.
-   Before release-environment approval, the release owner must cite the separate
-   Stage 3 handoff record, confirm each durable locator remains readable, and
-   verify the reviewed content against its recorded digest.
-6. Preserve the normal, race, GoDoc/API, and Resonance consumer artifacts. Each
-   artifact's source manifest records the candidate SHA, workflow definition
-   identity, run ID, and attempt. The release-gate record binds the four upload
-   artifact IDs, names, attempts, and SHA-256 digests to the exact Genesis and
-   Resonance commits. The release-evidence upload has its own independent tuple.
-   Before the tag is pushed, the protected job uses those exact IDs to query
-   Actions metadata, checks run/head/name/digest/size, and downloads and hashes
-   all five original ZIP archives. Immediately after the annotated tag is
-   pushed, the same job creates or resumes the exact GitHub prerelease draft and
-   uploads those ZIPs as Release assets. Actions uploads retain their source
-   copies for 90 days, while immutable Release assets are the durable archive.
-   The consumer artifact also records the original direct Genesis version and
-   the temporary replacement diff; its job must remove that replacement and
-   prove `go.mod`/`go.sum` clean before succeeding.
+2. Merge the Resonance compatibility changes and complete Stage 3 on that
+   protected `main` lineage. The six required rows are Compose, IM, Agent,
+   recovery, telemetry/alerts, and benchmark.
+3. Add the fixed Stage 3 JSON through an evidence-only Resonance PR. The final
+   consumer SHA is the merge commit containing that JSON; the manifest's
+   `tested_resonance_sha` remains the exact source commit exercised by Stage 3.
+4. Resolve every pre-tag item in the release notes and replace the draft marker
+   with the single exact line `Status: publication-ready.`.
+5. Dispatch the Genesis `main` CI with `candidate_tag=v1.0.0-rc.2`, the current
+   Genesis `main` SHA, the current Resonance `main` SHA, and
+   `final_release_preflight=true`. The final preflight requires the tracked
+   Stage 3 manifest, validates both repositories' exact tips, runs all normal,
+   race, API/GoDoc, quality, and consumer gates, and validates the byte-exact
+   release notes.
+6. Preserve the resulting normal, race, API/GoDoc, consumer, and
+   release-evidence artifact tuples. Each tuple consists of its Actions ID,
+   name, actual attempt, SHA-256, and downloaded byte size. Do not reconstruct
+   an artifact name from a later rerun attempt.
 
-Each upload job exports its actual artifact name and run attempt with its ID and
-digest. The release gate and annotated tag consume those outputs directly and
-record an independent tuple per artifact, plus the release-evidence artifact's
-own tuple. A partial rerun must not reconstruct prior names from the current
-`GITHUB_RUN_ATTEMPT`.
+An early dispatch may set `final_release_preflight=false`; it is diagnostic and
+does not authorize a tag. Only the successful final preflight is used below.
 
 ## 2. Configure the release authority
 
-The publish job deliberately does not give `GITHUB_TOKEN` write permission. It
-mints a short-lived token for a dedicated Genesis Release GitHub App from the
-protected `release` environment. Before enabling it:
+Genesis is a single-maintainer repository. The release identity is therefore
+the authenticated `ceyewan` account used by the local GitHub CLI, rather than a
+separate GitHub App. Before publication, verify through `gh api` that:
 
-1. Create and install a dedicated Release App on this repository with only
-   `Contents: write`, `Actions: read`, `Administration: read`, and
-   `Attestations: read`; record its client ID as the environment variable
-   `RELEASE_APP_CLIENT_ID` and its private key as the environment secret
-   `RELEASE_APP_PRIVATE_KEY`. The read permissions allow exact Actions archive
-   retrieval, immutable-setting verification, and release-attestation
-   verification. Do not grant Actions, Administration, or Attestations write.
-2. Create an active tag ruleset targeting `refs/tags/v*` that restricts tag
-   creation, update, and deletion. Make that dedicated App the only bypass
-   actor; do not grant a generic GitHub Actions or repository-role bypass.
-3. Create the `release` environment with required reviewers, prevent
-   self-review, and restrict deployments to protected `main` and `v*` tag runs.
-   The workflow itself permits prerelease publication only for the exact
-   `refs/tags/v1.0.0-rc.2` ref.
-4. Have an administrator enable GitHub immutable releases for the repository
-   and preserve API evidence of the setting. The App can read and enforce this
-   preconfigured setting but cannot change it.
-5. Verify those controls through the GitHub API and preserve the returned
-   ruleset/environment JSON with the release evidence. Only then set the
-   repository variable `RELEASE_TAG_PUBLISH_ENABLED=true`.
+- `gh auth status` reports the `ceyewan` account and the account has repository
+  administration permission;
+- the `release` environment requires `ceyewan` approval, permits self-review,
+  and accepts only the `main` branch and `v*` tags;
+- an active tag ruleset targets `refs/tags/v*`, restricts creation, update, and
+  deletion, and grants the `ceyewan` user the only configured bypass;
+- repository immutable releases are enabled; and
+- `v1.0.0-rc.2` does not already exist as a Git ref or GitHub Release.
 
-Rulesets grant bypass to an actor or App, not to an environment. The security
-boundary is therefore the combination of a dedicated App as the sole bypass
-actor and that App's private key being available only after protected
-environment approval. As of the 2026-08-09 candidate record, these remote
-controls remained unverified. That dated local record is not final proof; it
-must be replaced with current GitHub API evidence before publication, and the
-enable variable must remain absent/false until the checklist is completed.
+No personal token is stored in Actions secrets. The local publisher receives
+the current `gh auth token` only through the process environment and never
+prints or persists it. `GITHUB_TOKEN` remains read-only in CI. Preserve the
+environment, ruleset, immutable-setting, authenticated-user, and repository
+permission JSON with the release-owner record.
 
-## 3. Create the annotated tag and prerelease
+## 3. Create the annotated tag and prerelease with `gh`
 
-The protected `publish-tag` job creates the annotated tag only after the same
-dispatch has passed every release gate. The annotation binds the Genesis SHA
-to exactly one `Resonance-SHA:` line, the derived Stage 3 tuple, the preflight
-run, and all five artifact ID/name/attempt/digest/size tuples. The tag is
-therefore created only after the exact-source gates have succeeded and the
-original archive bytes remain available and hash correctly. A single Go
-validator first requires the exact release-notes title as the first line,
-exactly one `Status: publication-ready.` status line, no other status line, and
-no pending-before-tag section. It runs once in the release gate and again in
-`publish-tag` immediately before tag creation, so an immutable tag cannot be
-published with a body that the post-tag publisher must reject. Because the
-dedicated App token is not `GITHUB_TOKEN`, its push also triggers tag CI, which
-validates the annotation and reruns the complete gate as defense in depth.
+The release owner performs publication from a clean checkout of the successful
+final-preflight Genesis SHA:
 
-Lightweight tags are rejected. The publish job repeats the
-`origin/main == candidate SHA` check after any environment approval delay,
-immediately before tag creation. `main` may advance after tagging without
-invalidating the immutable release. Manual `git tag` or `git push` publication
-is not an approved release path, because it bypasses the pre-publication gate.
-After environment approval and before pushing, the job also queries Resonance
-`main` and requires exact equality with the bound consumer SHA, recording the
-remote tip and check time in the annotation. The tag-triggered defense run
-allows normal later `main` advancement only when that bound SHA remains an
-ancestor of the then-current tip.
+1. Revalidate the release notes with
+   `go run ./internal/cmd/publishprerelease --validate-only`.
+2. Read the successful workflow run and artifact metadata with `gh run view`
+   and `gh api`. Export the exact five preflight tuples, Stage 3 tuple, Genesis
+   and Resonance SHAs, `GITHUB_REPOSITORY=ceyewan/genesis`, and
+   `RELEASE_TOKEN="$(gh auth token)"` only for the publisher process.
+3. Run `publishprerelease --pre-tag-check <archive-dir>`. It rechecks immutable
+   releases, requires no conflicting tag Release, validates Actions lineage and
+   metadata, downloads each original ZIP by ID, and verifies its digest and
+   size.
+4. Recheck that Genesis and Resonance `main` still equal the bound SHAs. Render
+   the annotation with `.github/scripts/render-rc2-tag-annotation.sh`, create an
+   annotated `v1.0.0-rc.2` tag at the exact Genesis SHA, and push it with the
+   authenticated local `git`/`gh` identity. Lightweight or moved tags are not
+   accepted.
+5. Wait for the tag-triggered CI. It parses and validates the complete
+   annotation, reruns the full defense matrix, and uploads the independent
+   `tag-defense-evidence-<sha>-<run-id>-<attempt>` artifact.
+6. With the same local token, run `publishprerelease --stage-draft
+   <archive-dir>` to create or resume the exact five-asset draft. Then export
+   the tag-defense run/ID/name/attempt/digest and run `publishprerelease`
+   without mode flags. The publisher downloads and hashes the defense ZIP,
+   adds it as the sixth asset, publishes the prerelease, and waits until GitHub
+   reports `immutable: true` for the exact tag, target SHA, body, flags, and six
+   assets.
+7. Run the pinned or newer local `gh release verify v1.0.0-rc.2 --format json`
+   and preserve the output. Publication is complete only when the REST state
+   and attestation verification both succeed.
 
-Before the tag push, `publish-tag` also queries the immutable-releases endpoint
-with GitHub REST API version `2026-03-10` and downloads and hashes the five
-preflight archives. It requires the candidate tag to have no GitHub Release
-both before and after that download; a pre-created draft or published Release
-therefore fails before the tag is pushed. After the push, without another
-environment wait, it creates or resumes one exact draft, uploads only the five
-expected archives, reads back their uploaded state/size/SHA-256, and leaves the
-release as a prerelease draft. An unexpected release, asset, duplicate, or
-conflicting byte sequence is never deleted or overwritten. If a concurrent
-tag-triggered job has already published the exact Release while immutability is
-propagating, this staging step only polls to the bounded deadline and then
-validates the immutable six-asset result; it never uploads or PATCHes a
-published Release.
-
-After the tag-triggered defense-in-depth `release-gate` succeeds, the
-`publish-prerelease` job enters the same protected `release` environment and
-mints a new short-lived token from the dedicated Release App. It verifies the
-local annotated tag and exact draft identity/assets. The tag run's own
-release-evidence artifact uses the unique Actions name
-`tag-defense-evidence-<sha>-<run-id>-<actual-attempt>`. The publisher validates
-its current run/head/name/ID/digest/size through the Actions API, downloads and
-hashes its original ZIP, and adds it as the sixth asset. Its durable Release
-asset filename also encodes the Actions ID and digest, so this source tuple
-remains auditable after Actions retention expires.
-
-The publisher then rechecks the immutable setting immediately before the
-transition and PATCHes the draft into a
-non-draft prerelease whose body is byte-for-byte equal to
-`docs/v1-rc2-release-notes.md`. It then polls until the API reports
-`immutable: true` with the exact asset set. A partial draft can resume by
-downloading the annotation-bound Actions artifacts by ID; a published release
-is accepted only if its tag, title, body, flags, immutable state, and assets all
-match. The API response's `target_commitish` must also equal the candidate SHA,
-and the local annotated tag must peel to that same SHA. The workflow never
-overwrites a mismatched release or asset.
-
-If a failed-job rerun reuses the same tag-defense output tuple, an already
-uploaded sixth asset remains sufficient even after its Actions source expires.
-For a full rerun of the same tag workflow run, the run ID stays fixed while the
-attempt changes. An older draft asset becomes canonical only after its filename
-recovers the old Actions ID/digest and the still-available Actions metadata is
-revalidated against the exact run/head/name/digest/size; otherwise the mutable
-draft fails closed. Once the Release is immutable, that first accepted asset is
-the canonical defense evidence and later attempts verify it without adding or
-replacing assets. If a previous PATCH succeeded but immutability is still
-propagating, a rerun verifies identity and all six assets and only polls; an
-older-attempt defense source is still revalidated while the Release is mutable,
-and offline trust begins only after `immutable: true`. The rerun never sends a
-second PATCH.
-
-Before the irreversible PATCH, the workflow downloads GitHub CLI `v2.96.0`,
-verifies its pinned archive SHA-256, and checks the binary version. After the
-PATCH, it uses that exact binary to verify and record the immutable release
-attestation. Release publication is not reported green until both the REST
-immutable-state check and attestation verification succeed.
-
-### Fail-closed recovery
-
-Release asset processing and immutable-attestation generation can be
-eventually consistent. If an upload returns `422` while a same-name asset is
-still in a starter state or has no digest, the publisher fails without deleting
-or replacing anything. Wait for GitHub asset processing to settle, then rerun
-the same tag workflow. If it does not converge, the release owner must inspect
-the exact draft identity and asset set through the API and explicitly dispose of
-the abandoned draft before a new attempt; the workflow never performs that
-destructive recovery automatically.
-
-If the exact non-draft release or its attestation has not propagated before the
-bounded poll expires, first inspect the remote tag, target commit, byte-exact
-body, flags, immutable setting, and six assets. Rerun only when that remote state
-is exact: an already-PATCHed mutable release is polled without a second PATCH,
-and an immutable exact release is only reverified. For attestation propagation,
-wait and rerun the same tag workflow after the REST state is exact. Any identity,
-asset, or attestation mismatch remains a release-owner stop condition, not a
-reason to overwrite remote state.
-
-The publisher repeats the same positive readiness validation after the tag
-run. It does not remove or rewrite status or Pending text. The release owner
-must resolve the listed surface/security/retention decisions, replace the draft
-status with the exact publication-ready marker, remove the pre-tag Pending
-section, and freeze that byte-exact body in the tagged commit. Tag-qualified
-absolute documentation links are required because relative links in a Markdown
-source file do not keep their `docs/` context on a GitHub Release page.
+The publisher never overwrites a mismatched Release or asset. A partial exact
+draft may be resumed; an identity or digest mismatch is a hard stop. If GitHub
+asset, immutable-state, or attestation propagation times out, inspect the exact
+remote state and rerun only after it matches. Never delete or recreate the RC2
+tag to recover from a Release-side delay.
 
 ## 4. Verify the published module
 
-After the tag-triggered workflow has completed `publish-prerelease`, exact-six
-immutable-state verification, and attestation verification, and the module is
-visible through the public Go proxy, use a clean module cache and no local
-replacement:
+After the local `gh` publisher has completed exact-six immutable-state and
+attestation verification, and the module is visible through the public Go
+proxy, use a clean module cache and no local replacement:
 
 ```bash
 GOMODCACHE="$(mktemp -d)" GOPROXY=https://proxy.golang.org \

--- a/docs/v1-security-and-dependencies.md
+++ b/docs/v1-security-and-dependencies.md
@@ -51,15 +51,16 @@ The RC2 evidence must name the scanner and exact version or the explicit risk
 acceptance, the database snapshot/date when applicable, every finding and its
 reachability disposition, and the Genesis/Resonance SHAs tested. Repository
 rulesets, protected environment configuration, immutable releases, and the
-dedicated Release App's least-privilege authority are separate supply-chain
-controls and must also be verified before tag publication.
+authenticated release-owner identity are separate supply-chain controls and
+must also be verified before tag publication. Genesis is maintained by one
+developer, so the release owner uses the locally authenticated `gh` identity;
+no personal token is persisted in Actions secrets.
 
-The App is limited to `Contents: write` and read-only Actions, Administration,
-and Attestations permissions. Before the immutable transition, the protected
-workflow must preserve the five pre-tag Actions archives and the tag-defense
-evidence archive as an exact-six Release asset set. Publication is not green
-until the REST API reports `immutable: true` for that exact set and the pinned
-GitHub CLI verifies the Release attestation.
+Before the immutable transition, the release owner must preserve the five
+pre-tag Actions archives and the tag-defense evidence archive as an exact-six
+Release asset set. Publication is not green until the REST API reports
+`immutable: true` for that exact set and GitHub CLI verifies the Release
+attestation.
 
 The tracked Stage 3 manifest contains content digests, not raw-bundle locators.
 Its validator does not fetch those bundles. The release-environment approval

--- a/internal/cmd/publishprerelease/github.go
+++ b/internal/cmd/publishprerelease/github.go
@@ -117,7 +117,7 @@ func newPublisher(apiURL, repository, token string, client *http.Client) (*publi
 		return nil, fmt.Errorf("invalid GITHUB_REPOSITORY %q", repository)
 	}
 	if token == "" {
-		return nil, errors.New("RELEASE_APP_TOKEN is empty")
+		return nil, errors.New("RELEASE_TOKEN is empty")
 	}
 	if client == nil {
 		return nil, errors.New("HTTP client is nil")

--- a/internal/cmd/publishprerelease/main.go
+++ b/internal/cmd/publishprerelease/main.go
@@ -90,7 +90,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, output 
 	if apiURL == "" {
 		apiURL = defaultAPIURL
 	}
-	p, err := newPublisher(apiURL, getenv("GITHUB_REPOSITORY"), getenv("RELEASE_APP_TOKEN"), &http.Client{Timeout: githubHTTPTimeout})
+	p, err := newPublisher(apiURL, getenv("GITHUB_REPOSITORY"), getenv("RELEASE_TOKEN"), &http.Client{Timeout: githubHTTPTimeout})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- simplify the RC2 publication path for a single-maintainer repository
- keep GitHub Actions read-only and use the authenticated local `gh` identity for the protected tag and immutable prerelease
- retain exact-SHA, Stage 3, artifact digest, tag-defense, and exact-six release verification
- remove the dedicated GitHub App, repository secret, and self-review restrictions

## Validation

- `actionlint .github/workflows/ci.yml`
- `go test -count=1 ./internal/cmd/publishprerelease`
- `go test -race -count=1 ./internal/cmd/publishprerelease`
- `make markdown-check`
- `make modernize-check`
- `golangci-lint run ./internal/cmd/publishprerelease/...`
- `make api-inventory-check api-baseline-check api-compat-check`
- `git diff --check`

## Release scope

This PR changes the publication mechanism only. It does not create `v1.0.0-rc.2`; the tag remains gated on the merged SHA, final hosted preflight, Stage 3 evidence, and tag-defense run.
